### PR TITLE
chore(build): Use open source vrl fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10865,7 +10865,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vrl"
 version = "0.8.1"
-source = "git+ssh://git@github.com/answerbook/vrl.git?rev=v0.11.0#371100f562ef5480f72d8b258f682ce4ebdcf366"
+source = "git+ssh://git@github.com/mezmo/vrl.git?rev=v0.11.0#371100f562ef5480f72d8b258f682ce4ebdcf366"
 dependencies = [
  "aes",
  "ansi_term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ members = [
 ]
 
 [workspace.dependencies]
-vrl = { version = "0.8.1", git = "ssh://git@github.com/answerbook/vrl.git", rev = "v0.11.0", features = ["cli", "test", "test_framework", "arbitrary"] }
+vrl = { version = "0.8.1", git = "ssh://git@github.com/mezmo/vrl.git", rev = "v0.11.0", features = ["cli", "test", "test_framework", "arbitrary"] }
 pin-project = { version = "1.1.3", default-features = false }
 
 [dependencies]
@@ -228,8 +228,8 @@ number_prefix = { version = "0.4.0", default-features = false, features = ["std"
 ratatui = { version = "0.24.0", optional = true, default-features = false, features = ["crossterm"] }
 
 # Datadog Pipelines
-# datadog-filter = { package = "datadog-filter", git = "ssh://git@github.com/answerbook/vrl.git", rev = "v0.11.0" }
-# datadog-search-syntax = { package = "datadog-search-syntax", git = "ssh://git@github.com/answerbook/vrl.git", rev = "v0.11.0" }
+# datadog-filter = { package = "datadog-filter", git = "ssh://git@github.com/mezmo/vrl.git", rev = "v0.11.0" }
+# datadog-search-syntax = { package = "datadog-search-syntax", git = "ssh://git@github.com/mezmo/vrl.git", rev = "v0.11.0" }
 
 hex = { version = "0.4.3", default-features = false } # Do not do `optional`
 sha2 = { version = "0.10.8", default-features = false } # Do not do `optional`
@@ -380,7 +380,7 @@ tokio-test = "0.4.3"
 tower-test = "0.4.0"
 vector-lib = { path = "lib/vector-lib", default-features = false, features = ["vrl", "test"] }
 snap = "1"
-vrl = { version = "0.8.1", git = "ssh://git@github.com/answerbook/vrl.git", rev = "v0.11.0",features = ["cli", "test", "test_framework", "arbitrary"] }
+vrl = { version = "0.8.1", git = "ssh://git@github.com/mezmo/vrl.git", rev = "v0.11.0",features = ["cli", "test", "test_framework", "arbitrary"] }
 
 wiremock = "0.5.21"
 zstd = { version = "0.13.0", default-features = false }

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -43,7 +43,7 @@ indoc = { version = "2", default-features = false }
 tokio = { version = "1", features = ["test-util"] }
 quick-protobuf = "0.8"
 similar-asserts = "1.5.0"
-vrl = { version = "0.8.1", git = "ssh://git@github.com/answerbook/vrl.git", rev = "v0.11.0", features = ["cli", "test", "test_framework", "arbitrary"] }
+vrl = { version = "0.8.1", git = "ssh://git@github.com/mezmo/vrl.git", rev = "v0.11.0", features = ["cli", "test", "test_framework", "arbitrary"] }
 vector-core = { path = "../vector-core", default-features = false, features = ["test"] }
 
 [features]

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -98,7 +98,7 @@ rand = "0.8.5"
 rand_distr = "0.4.3"
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt", "ansi", "registry"] }
 vector-common = { path = "../vector-common", default-features = false, features = ["test"] }
-vrl = { version = "0.8.1", git = "ssh://git@github.com/answerbook/vrl.git", rev = "v0.11.0", features = ["cli", "test", "test_framework", "arbitrary"] }
+vrl = { version = "0.8.1", git = "ssh://git@github.com/mezmo/vrl.git", rev = "v0.11.0", features = ["cli", "test", "test_framework", "arbitrary"] }
 
 [features]
 api = ["dep:async-graphql"]

--- a/lib/vector-vrl/tests/Cargo.toml
+++ b/lib/vector-vrl/tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 enrichment = { path = "../../enrichment" }
-vrl = { version = "0.8.1", git = "ssh://git@github.com/answerbook/vrl.git", rev = "v0.11.0", features = ["test", "test_framework"] }
+vrl = { version = "0.8.1", git = "ssh://git@github.com/mezmo/vrl.git", rev = "v0.11.0", features = ["test", "test_framework"] }
 vector-vrl-functions = { path = "../../vector-vrl/functions" }
 
 ansi_term = "0.12"


### PR DESCRIPTION
Update the cargo build dependencies for the vrl package to point to the Mezmo open source fork instead of a private repo.

Ref: LOG-19155

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
