### PR TITLE
fix(ci): update `package.json` version via `npm` plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vector",
-  "version": "3.13.2",
+  "version": "3.13.4",
   "description": "Vector is a high-performance, end-to-end (agent & aggregator) observability data pipeline",
   "repository": {
     "type": "git",
@@ -21,6 +21,7 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
       [
         "@semantic-release/changelog", {
           "changelogFile": "MEZMO_CHANGELOG.md"


### PR DESCRIPTION
When releasing, we need the `npm` plugin to update the version in the `package.json` file. This file is only needed for releasing and tooling, however, part of `Jenkinsfile` needs it to be up-to-date so that `npm.semver()` works properly.

Ref: LOG-18250

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
