### PR TITLE
fix(ci): Add `package.json` into the semantic-release assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vector",
-  "version": "3.13.4",
+  "version": "3.13.5",
   "description": "Vector is a high-performance, end-to-end (agent & aggregator) observability data pipeline",
   "repository": {
     "type": "git",
@@ -34,7 +34,10 @@
       ],
       [
         "@semantic-release/git", {
-          "assets": "MEZMO_CHANGELOG.md"
+          "assets": [
+            "MEZMO_CHANGELOG.md",
+            "package.json"
+          ]
         }
       ]
     ]


### PR DESCRIPTION
Without `package.json` in the assets for the `@semantic-release/git` plugin, it will not update the version number as needed.

Ref: LOG-18250

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
