### PR TITLE
enhancement(exec source): Add support for executing VRL

### DIFF
--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -222,3 +222,29 @@ impl InternalEvent for ExecChannelClosedError {
         });
     }
 }
+
+#[derive(Debug)]
+pub struct ExecVrlEventsReceived<'a> {
+    pub count: usize,
+    pub source: &'a str,
+    pub byte_size: JsonSize,
+}
+
+impl InternalEvent for ExecVrlEventsReceived<'_> {
+    fn emit(self) {
+        trace!(
+            message = "Events received.",
+            count = self.count,
+            byte_size = self.byte_size.get(),
+            command = %self.source,
+        );
+        counter!(
+            "component_received_events_total", self.count as u64,
+            "source" => self.source.to_owned(),
+        );
+        counter!(
+            "component_received_event_bytes_total", self.byte_size.get() as u64,
+            "source" => self.source.to_owned(),
+        );
+    }
+}


### PR DESCRIPTION
Extends the exec source to allow exec a command
or VRL in either scheduled or streaming mode.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
