### PR TITLE
fix(ci): Turn back on commitlint and fix release regex

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
       // Do not run the stages on a release commit, unless it's for a sanity build.
       when {
         anyOf {
-          expression { !(env.TOP_COMMIT ==~ /^chore\(release\): \d+\.\d+\.\d+ \[skip ci\] by LogDNA Bot$/) }
+          expression { !(env.TOP_COMMIT ==~ /^release: 20\d\d-\d\d-\d\d, Version \d+\.\d+\.\d+ \[skip ci\] by LogDNA Bot$/) }
           environment name: 'SANITY_BUILD', value: 'true'
         }
       }
@@ -93,8 +93,7 @@ pipeline {
             script {
               configFileProvider(NPMRC) {
                 sh 'npm ci --ignore-scripts'
-                // Turn commitlint on when answerbook implements the same version of commitlint
-                // sh 'npm run commitlint'
+                sh 'npm run commitlint'
                 if (!env.CHANGE_FORK) {
                   sh 'npm run release:dry'
                 }
@@ -208,7 +207,7 @@ pipeline {
       when {
         allOf {
           branch DEFAULT_BRANCH
-          expression { env.TOP_COMMIT ==~ /^chore\(release\): \d+\.\d+\.\d+ \[skip ci\] by LogDNA Bot$/ }
+          expression { env.TOP_COMMIT ==~ /^release: 20\d\d-\d\d-\d\d, Version \d+\.\d+\.\d+ \[skip ci\] by LogDNA Bot$/ }
           not {
             environment name: 'SANITY_BUILD', value: 'true'
           }


### PR DESCRIPTION
Turn on `commitlint` now that bad commits have been dealt with. Also, the normal pattern for release commits is different than answerbook. So, make the regex for `TOP_COMMIT` respect the format this repo uses which is something like `release: 2024-05-15, Version 3.15.0 [skip ci]`.

Ref: LOG-19889

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
