### PR TITLE
fix(ci): Get semver tag during Publish stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -218,6 +218,8 @@ pipeline {
       }
       steps {
         script {
+          def semver = npm.semver() // get the tag
+
           buildx.build(
             project: PROJECT_NAME
           , push: true


### PR DESCRIPTION
Re-add the call to `semver` in the Publish stage. This gets the tag for releasing. Previous merge conflict resolution  somehow erased this code.

Ref: LOG-19889

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
