### PR TITLE
fix(release): regex needs to be correct

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,7 +211,7 @@ pipeline {
       when {
         allOf {
           branch DEFAULT_BRANCH
-          expression { env.TOP_COMMIT ==~ /^release: \d{4}-\d{2}-\d{2}, Version \d+\.\d+\.\d+ \[skip ci\]$/ }
+          expression { env.TOP_COMMIT ==~ /^release: \d{4}-\d{2}-\d{2}, Version \d+\.\d+\.\d+ \[skip ci\] by LogDNA Bot$/ }
           not {
             environment name: 'SANITY_BUILD', value: 'true'
           }


### PR DESCRIPTION
TOP_COMMIT is actually in this format:

```
> git log --pretty="format:%s by %cn" HEAD | head -1
release: 2025-08-05, Version 5.0.2 [skip ci] by LogDNA Bot
```

adjust regex to match

ref: LOG-22147
