### PR TITLE
Revert "chore(build): push build image to public and internal"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,13 +179,6 @@ pipeline {
               , args: [RELEASE_VERSION: pkg_version]
               , docker_repo: DOCKER_REPO
               )
-              buildx.build(
-                project: "${PROJECT_NAME}-mezmo"
-              , push: true
-              , tags: [tag]
-              , dockerfile: "distribution/docker/mezmo/Dockerfile"
-              , args: [RELEASE_VERSION: pkg_version]
-              )
             }
             sh './release-tool clean'
             sh "./release-tool build APP_VERSION='" + slugify("${CURRENT_BRANCH}-${BUILD_NUMBER}") + "'"
@@ -231,7 +224,6 @@ pipeline {
             returnStdout: true
           ).split(' = ')[1].trim()
 
-          // push to public
           buildx.build(
             project: PROJECT_NAME
           , push: true
@@ -239,15 +231,6 @@ pipeline {
           , dockerfile: "distribution/docker/mezmo/Dockerfile"
           , args: [RELEASE_VERSION: tag]
           , docker_repo: DOCKER_REPO
-          )
-
-          // push to internal
-          buildx.build(
-            project: "${PROJECT_NAME}-mezmo"
-          , push: true
-          , tags: [tag]
-          , dockerfile: "distribution/docker/mezmo/Dockerfile"
-          , args: [RELEASE_VERSION: tag]
           )
         }
         sh './release-tool clean'


### PR DESCRIPTION
This reverts commit fba7e09a3f0c061d56c18edffad25f588347dd7d.

we now have an internal mirror in google artifact repository for the public image on dockerhub.  no reason to build it twice.

ref: LOG-22147
