### PR TITLE
chore(sources): add upstream opentelemetry source to mezmo build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -644,6 +644,7 @@ sources-logs-mezmo = [
   "sources-mezmo_user_logs",
   "sources-kafka",
   "sources-kubernetes_logs",
+  "sources-opentelemetry",
   "sources-pulsar",
   "sources-stdin",
   "sources-syslog",


### PR DESCRIPTION

bring in http/grpc upstream source for edge.

ref: LOG-22201