### PR TITLE
fix(fetch_tasks): do not send content type on get request && chore(build): update docker org for image publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def WORKSPACE_PATH = "/tmp/workspace/${env.BUILD_TAG.replace('%2F', '/')}"
 def DEFAULT_BRANCH = "master"
 def PROJECT_NAME = "vector"
 def CURRENT_BRANCH = currentBranch()
-def DOCKER_REPO = "docker.io/mezmohq"
+def DOCKER_REPO = "docker.io/mezmo"
 
 def slugify(str) {
   def s = str.toLowerCase()


### PR DESCRIPTION
chore(build): update docker org for image publishing

we are consolidating our public docker organization to `mezmo`.

ref: LOG-22293

---

fix(fetch_tasks): do not send content type on get request

get requests don't have a request body, so don't send a content-type
along with the request.

ref: LOG-22372