### PR TITLE
fix(sources): Re-implement Pulsar's use of the admin api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "regex",
@@ -3715,7 +3715,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4108,7 +4108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5540,7 +5540,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing 0.1.44",
@@ -5743,7 +5743,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing 0.1.44",
@@ -6111,7 +6111,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7698,7 +7698,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9041,7 +9041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.11.1",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -9061,12 +9061,12 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.12.1",
+ "heck 0.5.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
- "petgraph 0.6.5",
+ "petgraph 0.7.1",
  "prettyplease 0.2.37",
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -9108,7 +9108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -9214,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "pulsar"
 version = "6.4.1"
-source = "git+https://github.com/mezmo/pulsar-rs?rev=fa9fe2a68e98793e3b2d371827109ce8c8cf52f0#fa9fe2a68e98793e3b2d371827109ce8c8cf52f0"
+source = "git+https://github.com/mezmo/pulsar-rs?rev=6ec1d87cdd925b2b1b5f8526c5b01a6b3f865e27#6ec1d87cdd925b2b1b5f8526c5b01a6b3f865e27"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -9371,7 +9371,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing 0.1.44",
@@ -9408,9 +9408,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing 0.1.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10339,7 +10339,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11280,7 +11280,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -11892,7 +11892,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11912,7 +11912,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,7 +411,7 @@ openssl-probe = { version = "0.1.6", default-features = false }
 ordered-float.workspace = true
 percent-encoding = { version = "2.3.1", default-features = false }
 postgres-openssl = { version = "0.5.1", default-features = false, features = ["runtime"], optional = true }
-pulsar = { git = "https://github.com/mezmo/pulsar-rs", rev = "fa9fe2a68e98793e3b2d371827109ce8c8cf52f0", default-features = false, features = ["tokio-runtime", "admin-api", "auth-oauth2", "flate2", "lz4", "snap", "zstd"], optional = true }
+pulsar = { git = "https://github.com/mezmo/pulsar-rs", rev = "6ec1d87cdd925b2b1b5f8526c5b01a6b3f865e27", default-features = false, features = ["tokio-runtime", "admin-api", "auth-oauth2", "flate2", "lz4", "snap", "zstd"], optional = true }
 quick-junit = { version = "0.5.1" }
 rand.workspace = true
 rand_distr.workspace = true

--- a/src/sources/pulsar.rs
+++ b/src/sources/pulsar.rs
@@ -8,8 +8,7 @@ use bytes::Bytes;
 use chrono::TimeZone;
 use futures_util::StreamExt;
 use pulsar::{
-    Authentication, BrokerConfigOptions, ConnectionRetryOptions, Consumer, Pulsar, SubType,
-    TokioExecutor,
+    Authentication, ConnectionRetryOptions, Consumer, Pulsar, SubType, TokioExecutor,
     authentication::oauth2::{OAuth2Authentication, OAuth2Params},
     consumer::{InitialPosition, Message},
     message::proto::MessageIdData,
@@ -63,6 +62,13 @@ pub struct PulsarSourceConfig {
     #[configurable(metadata(docs::examples = "pulsar://127.0.0.1:6650"))]
     #[serde(alias = "address")]
     endpoint: String,
+
+    /// The base URL of the Pulsar Admin HTTP endpoint.
+    ///
+    /// Required when `broker_config_options` is set. If not provided, broker-side
+    /// topic policies will not be applied.
+    #[configurable(metadata(docs::examples = "http://127.0.0.1:8080"))]
+    admin_endpoint: Option<String>,
 
     /// The Pulsar topic names to read events from.
     #[configurable(metadata(docs::examples = "[persistent://public/default/my-topic]"))]
@@ -347,18 +353,11 @@ pub struct PulsarConnectionRetryOptions {
 #[derive(Clone, Debug)]
 pub struct PulsarBrokerConfigOptions {
     /// Maximum number of unacknowledged messages allowed per consumer on a topic.
-    /// Requires the `admin-api` feature in the pulsar crate and `topicLevelPoliciesEnabled=true`
-    /// in the broker configuration.
+    ///
+    /// Applied via the Pulsar Admin REST API after the consumer subscribes. Requires
+    /// `admin_endpoint` to be set in this source's configuration.
     #[configurable(metadata(docs::examples = 1000))]
     pub max_unacked_messages_per_consumer: Option<u32>,
-}
-
-impl From<&PulsarBrokerConfigOptions> for BrokerConfigOptions {
-    fn from(opts: &PulsarBrokerConfigOptions) -> Self {
-        BrokerConfigOptions {
-            max_unacked_messages_per_consumer: opts.max_unacked_messages_per_consumer,
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -439,12 +438,7 @@ impl PulsarSourceConfig {
     async fn create_consumer(
         &self,
     ) -> crate::Result<pulsar::consumer::Consumer<String, TokioExecutor>> {
-        let admin_url_env_var = std::env::var("PULSAR_ADMIN_URL").ok();
-
         let mut builder = Pulsar::builder(&self.endpoint, TokioExecutor);
-        if let Some(admin_url) = admin_url_env_var {
-            builder = builder.with_admin_url(admin_url);
-        }
 
         let mut retry_options = ConnectionRetryOptions {
             // Use an infinite number of retries by default so that Vector doesn't
@@ -585,11 +579,35 @@ impl PulsarSourceConfig {
             consumer_builder = consumer_builder.with_topics(&self.topics);
         }
 
-        if let Some(broker_config) = &self.broker_config_options {
-            consumer_builder = consumer_builder.with_broker_config(broker_config.into());
-        }
-
         let consumer = consumer_builder.build::<String>().await?;
+
+        // Apply broker-side topic policies via the admin API after the consumer has
+        // subscribed (the topic must exist first). Errors are logged and ignored so
+        // that a misconfigured or unavailable admin endpoint does not prevent Vector
+        // from starting up.
+        if let (Some(admin_url), Some(broker_config)) =
+            (&self.admin_endpoint, &self.broker_config_options)
+            && let Some(max_unacked) = broker_config.max_unacked_messages_per_consumer
+        {
+            match pulsar.admin(admin_url) {
+                Ok(admin) => {
+                    for topic in &self.topics {
+                        if let Err(e) = admin
+                            .set_max_unacked_messages_per_consumer(topic, max_unacked)
+                            .await
+                        {
+                            warn!(
+                                "Failed to set max_unacked_messages_per_consumer on topic \
+                                 {topic}: {e}"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to create Pulsar admin client for {admin_url}: {e}");
+                }
+            }
+        }
 
         Ok(consumer)
     }
@@ -986,6 +1004,24 @@ mod tests {
     }
 
     #[test]
+    fn parse_admin_endpoint() {
+        let config = config_from_str(r#"admin_endpoint = "http://127.0.0.1:8080""#);
+        assert_eq!(
+            config.admin_endpoint.as_deref(),
+            Some("http://127.0.0.1:8080")
+        );
+    }
+
+    #[test]
+    fn no_admin_endpoint_is_none() {
+        let config = config_from_str("");
+        assert!(
+            config.admin_endpoint.is_none(),
+            "Expected admin_endpoint to be None when not in config"
+        );
+    }
+
+    #[test]
     fn parse_broker_config_options_full() {
         let config = config_from_str(
             r#"
@@ -1138,6 +1174,7 @@ mod integration_tests {
             partitioned_topic_auto_discovery: false,
             topic_refresh_secs: 30,
             connection_retry_options: None,
+            admin_endpoint: None,
             broker_config_options: None,
         };
         let mut builder = Pulsar::<TokioExecutor>::builder(&cnf.endpoint, TokioExecutor);
@@ -1232,6 +1269,7 @@ mod integration_tests {
             partitioned_topic_auto_discovery: true,
             topic_refresh_secs: 10,
             connection_retry_options: None,
+            admin_endpoint: None,
             broker_config_options: None,
         };
 
@@ -1269,6 +1307,7 @@ mod integration_tests {
             partitioned_topic_auto_discovery: true,
             topic_refresh_secs: 15,
             connection_retry_options: None,
+            admin_endpoint: None,
             broker_config_options: None,
         };
 
@@ -1305,6 +1344,7 @@ mod integration_tests {
             partitioned_topic_auto_discovery: false,
             topic_refresh_secs: 20,
             connection_retry_options: None,
+            admin_endpoint: None,
             broker_config_options: None,
         };
 
@@ -1341,6 +1381,7 @@ mod integration_tests {
             partitioned_topic_auto_discovery: true,
             topic_refresh_secs: 30,
             connection_retry_options: None,
+            admin_endpoint: None,
             broker_config_options: None,
         };
 
@@ -1388,6 +1429,7 @@ mod integration_tests {
             partitioned_topic_auto_discovery: true,
             topic_refresh_secs: 30,
             connection_retry_options: None,
+            admin_endpoint: None,
             broker_config_options: None,
         };
 
@@ -1435,6 +1477,7 @@ mod integration_tests {
             partitioned_topic_auto_discovery: true,
             topic_refresh_secs: 30,
             connection_retry_options: None,
+            admin_endpoint: None,
             broker_config_options: None,
         };
 
@@ -1485,6 +1528,7 @@ mod integration_tests {
                 partitioned_topic_auto_discovery: true,
                 topic_refresh_secs: refresh_secs,
                 connection_retry_options: None,
+                admin_endpoint: None,
                 broker_config_options: None,
             };
 
@@ -1528,6 +1572,7 @@ mod integration_tests {
                 partitioned_topic_auto_discovery: true,
                 topic_refresh_secs: 30,
                 connection_retry_options: None,
+                admin_endpoint: None,
                 broker_config_options: None,
             };
 
@@ -1540,66 +1585,113 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn test_broker_config_admin_error_is_swallowed() {
+        trace_init();
+
+        let topic = format!("persistent://public/default/test-{}", random_string(10));
+
+        // Point admin_endpoint at a port with nothing listening. The consumer
+        // subscription itself should still succeed — the admin error is warned
+        // and ignored so Vector startup is not blocked.
+        let cnf = PulsarSourceConfig {
+            endpoint: pulsar_address("pulsar", 6650),
+            topics: vec![topic.clone()],
+            consumer_name: Some("test-admin-error-consumer".to_string()),
+            subscription_name: Some("test-admin-error-sub".to_string()),
+            priority_level: None,
+            batch_size: None,
+            auth: None,
+            dead_letter_queue_policy: None,
+            subscription_type: SubscriptionType::default(),
+            consumer_position: ConsumerPosition::default(),
+            framing: FramingConfig::Bytes,
+            decoding: DeserializerConfig::Bytes,
+            acknowledgements: false.into(),
+            log_namespace: None,
+            broker_redelivery_enabled: false,
+            tls: None,
+            partitioned_topic_auto_discovery: false,
+            topic_refresh_secs: 30,
+            connection_retry_options: None,
+            admin_endpoint: Some("http://127.0.0.1:1".to_string()),
+            broker_config_options: Some(PulsarBrokerConfigOptions {
+                max_unacked_messages_per_consumer: Some(500),
+            }),
+        };
+
+        let result = cnf.create_consumer().await;
+        assert!(
+            result.is_ok(),
+            "Consumer creation should succeed even when the admin endpoint is unreachable: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
     async fn test_broker_config_max_unacked_messages() {
         trace_init();
 
         let admin_url = pulsar_admin_url();
         let topic = format!("persistent://public/default/test-{}", random_string(10));
 
-        temp_env::async_with_vars([("PULSAR_ADMIN_URL", Some(&admin_url))], async {
-            let cnf = PulsarSourceConfig {
-                endpoint: pulsar_address("pulsar", 6650),
-                topics: vec![topic.clone()],
-                consumer_name: Some("test-admin-consumer".to_string()),
-                subscription_name: Some("test-admin-sub".to_string()),
-                priority_level: None,
-                batch_size: None,
-                auth: None,
-                dead_letter_queue_policy: None,
-                subscription_type: SubscriptionType::default(),
-                consumer_position: ConsumerPosition::default(),
-                framing: FramingConfig::Bytes,
-                decoding: DeserializerConfig::Bytes,
-                acknowledgements: false.into(),
-                log_namespace: None,
-                broker_redelivery_enabled: false,
-                tls: None,
-                partitioned_topic_auto_discovery: false,
-                topic_refresh_secs: 30,
-                connection_retry_options: None,
-                broker_config_options: Some(PulsarBrokerConfigOptions {
-                    max_unacked_messages_per_consumer: Some(500),
-                }),
-            };
+        let cnf = PulsarSourceConfig {
+            endpoint: pulsar_address("pulsar", 6650),
+            topics: vec![topic.clone()],
+            consumer_name: Some("test-admin-consumer".to_string()),
+            subscription_name: Some("test-admin-sub".to_string()),
+            priority_level: None,
+            batch_size: None,
+            auth: None,
+            dead_letter_queue_policy: None,
+            subscription_type: SubscriptionType::default(),
+            consumer_position: ConsumerPosition::default(),
+            framing: FramingConfig::Bytes,
+            decoding: DeserializerConfig::Bytes,
+            acknowledgements: false.into(),
+            log_namespace: None,
+            broker_redelivery_enabled: false,
+            tls: None,
+            partitioned_topic_auto_discovery: false,
+            topic_refresh_secs: 30,
+            connection_retry_options: None,
+            admin_endpoint: Some(admin_url.clone()),
+            broker_config_options: Some(PulsarBrokerConfigOptions {
+                max_unacked_messages_per_consumer: Some(500),
+            }),
+        };
 
-            let _consumer = cnf.create_consumer().await.unwrap();
+        let _consumer = cnf.create_consumer().await.unwrap();
 
-            let topic_name = topic.split('/').next_back().unwrap();
-            let url = format!(
-                "{admin_url}/admin/v2/persistent/public/default/{topic_name}/maxUnackedMessagesOnConsumer",
+        let topic_name = topic.split('/').next_back().unwrap();
+        let url = format!(
+            "{admin_url}/admin/v2/persistent/public/default/{topic_name}/maxUnackedMessagesOnConsumer",
+        );
+
+        // Topic-level policies propagate asynchronously; poll until the value appears
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let value: i32 = loop {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            let resp = reqwest::get(&url).await.unwrap();
+            assert!(
+                resp.status().is_success(),
+                "Admin API GET failed with status: {}",
+                resp.status()
             );
-
-            // Topic-level policies propagate asynchronously; poll until the value appears
-            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
-            let value: i32 = loop {
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                let resp = reqwest::get(&url).await.unwrap();
-                assert!(
-                    resp.status().is_success(),
-                    "Admin API GET failed with status: {}",
-                    resp.status()
-                );
-                let body = resp.text().await.unwrap();
-                if !body.is_empty() {
-                    break body.trim().parse().expect("expected integer from admin API");
-                }
-                assert!(
-                    tokio::time::Instant::now() < deadline,
-                    "Timed out waiting for max_unacked_messages_per_consumer policy to propagate"
-                );
-            };
-            assert_eq!(value, 500, "Expected max_unacked_messages_per_consumer=500, got {value}");
-        })
-        .await;
+            let body = resp.text().await.unwrap();
+            if !body.is_empty() {
+                break body
+                    .trim()
+                    .parse()
+                    .expect("expected integer from admin API");
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out waiting for max_unacked_messages_per_consumer policy to propagate"
+            );
+        };
+        assert_eq!(
+            value, 500,
+            "Expected max_unacked_messages_per_consumer=500, got {value}"
+        );
     }
 }


### PR DESCRIPTION
We need to use the admin API in vector to set things like topic-level policies.  The implementation has changed in `pulsar-rs` per our fork and upstream PR. Mainly, the consumer was decoupled from the admin client, the ENV var for the pulsar apis has been removed in favor of a configuration value for `admin_endpoint`, and errors are ignored when the admin endpoints fail.

Ref: LOG-23536


