### PR TITLE
feat(sinks): add `network_mock` sink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -952,6 +952,7 @@ sinks-logs-mezmo = [
   "sinks-blackhole",
   "sinks-console",
   "sinks-clickhouse",
+  "sinks-network_mock",
   "sinks-datadog_logs",
   "sinks-datadog_traces",
   "sinks-elasticsearch",
@@ -1037,6 +1038,7 @@ sinks-mezmo = []
 sinks-loki = ["loki-logproto"]
 sinks-mqtt = ["dep:rumqttc"]
 sinks-nats = ["dep:async-nats", "dep:nkeys"]
+sinks-network_mock = []
 sinks-new_relic_logs = ["sinks-http"]
 sinks-new_relic = []
 sinks-opentelemetry = ["sinks-http", "codecs-opentelemetry"]

--- a/lib/vector-core/src/usage_metrics/mod.rs
+++ b/lib/vector-core/src/usage_metrics/mod.rs
@@ -666,6 +666,10 @@ async fn get_flusher(
         if db_url == "log://stderr" {
             return Ok(Arc::new(StdErrFlusher {}));
         }
+        // Discard metrics entirely — useful for pods without a metrics DB
+        if db_url == "log://null" {
+            return Ok(Arc::new(NoopFlusher {}));
+        }
 
         return Ok(Arc::new(
             DbFlusher::new(&pod_name)

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -82,6 +82,8 @@ pub mod mezmo_opentelemetry;
 pub mod mqtt;
 #[cfg(feature = "sinks-nats")]
 pub mod nats;
+#[cfg(feature = "sinks-network_mock")]
+pub mod network_mock;
 #[cfg(feature = "sinks-new_relic")]
 pub mod new_relic;
 #[cfg(feature = "sinks-webhdfs")]

--- a/src/sinks/network_mock/config.rs
+++ b/src/sinks/network_mock/config.rs
@@ -1,0 +1,146 @@
+use futures::FutureExt;
+use vector_lib::configurable::configurable_component;
+
+use super::{
+    encoder::NetworkMockEncoder,
+    request_builder::NetworkMockRequestBuilder,
+    service::{NetworkMockRetryLogic, NetworkMockService},
+    sink::NetworkMockSink,
+};
+use crate::sinks::{prelude::*, util::BatchConfig};
+
+/// Latency simulation settings.
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub struct LatencyConfig {
+    /// Mean latency in milliseconds per simulated request.
+    #[serde(default = "default_mean_ms")]
+    mean_ms: u64,
+
+    /// Maximum jitter in milliseconds, applied uniformly around the mean.
+    /// Actual latency per request is `mean_ms + uniform(-jitter_ms, +jitter_ms)`.
+    #[serde(default = "default_jitter_ms")]
+    jitter_ms: u64,
+}
+
+impl Default for LatencyConfig {
+    fn default() -> Self {
+        Self {
+            mean_ms: default_mean_ms(),
+            jitter_ms: default_jitter_ms(),
+        }
+    }
+}
+
+const fn default_mean_ms() -> u64 {
+    50
+}
+
+const fn default_jitter_ms() -> u64 {
+    10
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct NetworkMockDefaultBatchSettings;
+
+impl SinkBatchSettings for NetworkMockDefaultBatchSettings {
+    const MAX_EVENTS: Option<usize> = Some(1000);
+    const MAX_BYTES: Option<usize> = Some(1_048_576);
+    const TIMEOUT_SECS: f64 = 1.0;
+}
+
+/// Configuration for the `network_mock` sink.
+#[configurable_component(sink(
+    "network_mock",
+    "Simulate network request behavior for throughput testing."
+))]
+#[derive(Clone, Debug)]
+pub struct NetworkMockConfig {
+    /// Latency simulation settings.
+    #[configurable(derived)]
+    #[serde(default)]
+    latency: LatencyConfig,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    batch: BatchConfig<NetworkMockDefaultBatchSettings>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    request: TowerRequestConfig,
+
+    /// Fraction of requests that return a retriable error (0.0 to 1.0).
+    #[serde(default)]
+    error_rate: f64,
+
+    #[configurable(derived)]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    encoding: Transformer,
+
+    #[configurable(derived)]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::is_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
+}
+
+impl GenerateConfig for NetworkMockConfig {
+    fn generate_config() -> toml::Value {
+        toml::from_str("").unwrap()
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "network_mock")]
+impl SinkConfig for NetworkMockConfig {
+    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        if !(0.0..=1.0).contains(&self.error_rate) {
+            return Err("error_rate must be between 0.0 and 1.0".into());
+        }
+
+        let batch_settings = self.batch.validate()?.into_batcher_settings()?;
+
+        let request_builder = NetworkMockRequestBuilder {
+            encoder: NetworkMockEncoder {
+                transformer: self.encoding.clone(),
+            },
+            compression: Compression::None,
+        };
+
+        let service = NetworkMockService {
+            mean_ms: self.latency.mean_ms,
+            jitter_ms: self.latency.jitter_ms,
+            error_rate: self.error_rate,
+        };
+
+        let request_limits = self.request.into_settings();
+        let service = ServiceBuilder::new()
+            .settings(request_limits, NetworkMockRetryLogic)
+            .service(service);
+
+        let sink = NetworkMockSink::new(service, batch_settings, request_builder);
+        let healthcheck = futures::future::ok(()).boxed();
+
+        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn input(&self) -> Input {
+        Input::log()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<NetworkMockConfig>();
+    }
+}

--- a/src/sinks/network_mock/encoder.rs
+++ b/src/sinks/network_mock/encoder.rs
@@ -1,0 +1,35 @@
+use std::io;
+
+use serde_json::json;
+
+use crate::sinks::{
+    prelude::*,
+    util::encoding::{Encoder as SinkEncoder, write_all},
+};
+
+pub(super) struct NetworkMockEncoder {
+    pub(super) transformer: Transformer,
+}
+
+impl SinkEncoder<Vec<Event>> for NetworkMockEncoder {
+    fn encode_input(
+        &self,
+        events: Vec<Event>,
+        writer: &mut dyn io::Write,
+    ) -> io::Result<(usize, GroupedCountByteSize)> {
+        let mut byte_size = telemetry().create_request_count_byte_size();
+        let n_events = events.len();
+        let mut json_events: Vec<serde_json::Value> = Vec::with_capacity(n_events);
+
+        for mut event in events {
+            self.transformer.transform(&mut event);
+            byte_size.add_event(&event, event.estimated_json_encoded_size_of());
+            json_events.push(json!(event.as_log()));
+        }
+
+        let body = serde_json::to_vec(&json_events)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        write_all(writer, n_events, &body).map(|()| (body.len(), byte_size))
+    }
+}

--- a/src/sinks/network_mock/mod.rs
+++ b/src/sinks/network_mock/mod.rs
@@ -1,0 +1,11 @@
+//! A mock network sink for realistic throughput testing.
+//!
+//! This sink exercises the full Tower service pipeline (batching, encoding,
+//! request building, concurrency control, retries) while replacing the actual
+//! network call with a configurable sleep, optionally simulating request errors.
+
+mod config;
+mod encoder;
+mod request_builder;
+mod service;
+mod sink;

--- a/src/sinks/network_mock/request_builder.rs
+++ b/src/sinks/network_mock/request_builder.rs
@@ -1,0 +1,46 @@
+use std::io;
+
+use bytes::Bytes;
+
+use super::encoder::NetworkMockEncoder;
+use crate::sinks::{prelude::*, util::http::HttpRequest};
+
+pub(super) struct NetworkMockRequestBuilder {
+    pub(super) encoder: NetworkMockEncoder,
+    pub(super) compression: Compression,
+}
+
+impl RequestBuilder<Vec<Event>> for NetworkMockRequestBuilder {
+    type Metadata = EventFinalizers;
+    type Events = Vec<Event>;
+    type Encoder = NetworkMockEncoder;
+    type Payload = Bytes;
+    type Request = HttpRequest<()>;
+    type Error = io::Error;
+
+    fn compression(&self) -> Compression {
+        self.compression
+    }
+
+    fn encoder(&self) -> &Self::Encoder {
+        &self.encoder
+    }
+
+    fn split_input(
+        &self,
+        mut events: Vec<Event>,
+    ) -> (Self::Metadata, RequestMetadataBuilder, Self::Events) {
+        let finalizers = events.take_finalizers();
+        let builder = RequestMetadataBuilder::from_events(&events);
+        (finalizers, builder, events)
+    }
+
+    fn build_request(
+        &self,
+        metadata: Self::Metadata,
+        request_metadata: RequestMetadata,
+        payload: EncodeResult<Self::Payload>,
+    ) -> Self::Request {
+        HttpRequest::new(payload.into_payload(), metadata, request_metadata, ())
+    }
+}

--- a/src/sinks/network_mock/service.rs
+++ b/src/sinks/network_mock/service.rs
@@ -1,0 +1,106 @@
+use std::fmt;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use crate::sinks::{prelude::*, util::http::HttpRequest};
+
+// Response
+
+pub(super) struct NetworkMockResponse {
+    events_byte_size: GroupedCountByteSize,
+    raw_byte_size: usize,
+}
+
+impl DriverResponse for NetworkMockResponse {
+    fn event_status(&self) -> EventStatus {
+        EventStatus::Delivered
+    }
+
+    fn events_sent(&self) -> &GroupedCountByteSize {
+        &self.events_byte_size
+    }
+
+    fn bytes_sent(&self) -> Option<usize> {
+        Some(self.raw_byte_size)
+    }
+}
+
+// Error
+
+#[derive(Debug)]
+pub(super) struct NetworkMockError;
+
+impl fmt::Display for NetworkMockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("network_mock: simulated request failure")
+    }
+}
+
+impl std::error::Error for NetworkMockError {}
+
+// Service
+
+#[derive(Clone)]
+pub(super) struct NetworkMockService {
+    pub(super) mean_ms: u64,
+    pub(super) jitter_ms: u64,
+    pub(super) error_rate: f64,
+}
+
+impl Service<HttpRequest<()>> for NetworkMockService {
+    type Response = NetworkMockResponse;
+    type Error = NetworkMockError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, mut request: HttpRequest<()>) -> Self::Future {
+        let metadata = std::mem::take(request.metadata_mut());
+        let raw_byte_size = metadata.request_encoded_size();
+        let events_byte_size = metadata.into_events_estimated_json_encoded_byte_size();
+
+        let mean_ms = self.mean_ms;
+        let jitter_ms = self.jitter_ms;
+        let error_rate = self.error_rate;
+
+        Box::pin(async move {
+            let latency = if jitter_ms > 0 {
+                let jitter = rand::random::<u64>() % (jitter_ms * 2 + 1);
+                let offset = mean_ms.saturating_sub(jitter_ms) + jitter;
+                Duration::from_millis(offset)
+            } else {
+                Duration::from_millis(mean_ms)
+            };
+
+            debug!("Simulated request latency: {:?}", latency);
+            tokio::time::sleep(latency).await;
+
+            if error_rate > 0.0 && rand::random::<f64>() < error_rate {
+                warn!(message = "Simulated request error.", error_rate);
+                return Err(NetworkMockError);
+            }
+
+            Ok(NetworkMockResponse {
+                events_byte_size,
+                raw_byte_size,
+            })
+        })
+    }
+}
+
+// Retry logic
+
+#[derive(Debug, Clone)]
+pub(super) struct NetworkMockRetryLogic;
+
+impl RetryLogic for NetworkMockRetryLogic {
+    type Error = NetworkMockError;
+    type Request = HttpRequest<()>;
+    type Response = NetworkMockResponse;
+
+    fn is_retriable_error(&self, _error: &Self::Error) -> bool {
+        true
+    }
+}

--- a/src/sinks/network_mock/sink.rs
+++ b/src/sinks/network_mock/sink.rs
@@ -1,0 +1,68 @@
+use super::request_builder::NetworkMockRequestBuilder;
+use crate::sinks::{
+    prelude::*,
+    util::http::{HttpJsonBatchSizer, HttpRequest},
+};
+
+pub(super) struct NetworkMockSink<S> {
+    service: S,
+    batch_settings: BatcherSettings,
+    request_builder: NetworkMockRequestBuilder,
+}
+
+impl<S> NetworkMockSink<S>
+where
+    S: Service<HttpRequest<()>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: DriverResponse + Send + 'static,
+    S::Error: std::fmt::Debug + Into<crate::Error> + Send,
+{
+    pub(super) const fn new(
+        service: S,
+        batch_settings: BatcherSettings,
+        request_builder: NetworkMockRequestBuilder,
+    ) -> Self {
+        Self {
+            service,
+            batch_settings,
+            request_builder,
+        }
+    }
+
+    async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        input
+            .batched(self.batch_settings.as_item_size_config(HttpJsonBatchSizer))
+            .request_builder(
+                default_request_builder_concurrency_limit(),
+                self.request_builder,
+            )
+            .filter_map(|request| async move {
+                match request {
+                    Err(error) => {
+                        emit!(SinkRequestBuildError { error });
+                        None
+                    }
+                    Ok(req) => Some(req),
+                }
+            })
+            .into_driver(self.service)
+            .run()
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl<S> StreamSink<Event> for NetworkMockSink<S>
+where
+    S: Service<HttpRequest<()>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: DriverResponse + Send + 'static,
+    S::Error: std::fmt::Debug + Into<crate::Error> + Send,
+{
+    async fn run(
+        self: Box<Self>,
+        input: futures_util::stream::BoxStream<'_, Event>,
+    ) -> Result<(), ()> {
+        self.run_inner(input).await
+    }
+}


### PR DESCRIPTION
This sink functions like a `blackhole` sink, but exercises the full lifecycle of other sinks that make network requests using a Tower service (batching, encoding, request building, concurrency control, retries, acknowledgements). Supports configurable latency (mean + jitter), error rate simulation, and standard batch/request settings.

Ref: LOG-23599

### Example

```rust
[api]
enabled = true

[sources.demo]
type = "demo_logs"
format = "json"
interval = 0.01

[sinks.mock]
type = "network_mock"
inputs = ["demo"]
error_rate = 0.5

  [sinks.mock.latency]
  mean_ms = 50
  jitter_ms = 10

  [sinks.mock.buffer]
  max_events = ${MEZMO_MEM_BUFFER_MAX_EVENTS:-10000}
  when_full = "block"

  [sinks.mock.batch]
  max_bytes = 2_097_151

  [sinks.mock.request]
  retry_attempts = 10
  retry_initial_backoff_secs = 1
  retry_max_duration_secs = 10
  timeout_secs = 30
  rate_limit_duration_secs = 1

  [sinks.mock.acknowledegments]
  enabled = true

```