### PR TITLE
fix(transforms): RocksDB transforms should take finalizers early

### DIFF
--- a/src/transforms/mezmo_aggregate_v2/mod.rs
+++ b/src/transforms/mezmo_aggregate_v2/mod.rs
@@ -299,7 +299,14 @@ impl MezmoAggregateV2 {
     /// Executes the aggregation program with the new event, collecting the aggregate into sliding windows. Aggregate
     /// events that are ready to be released/flushed will not be further mutated but remain in memory until the flush
     /// method is called, typically on a polling cycle.
-    fn record(&mut self, event: Event) {
+    fn record(&mut self, mut event: Event) {
+        // Ack the source event on receipt rather than holding its finalizers in aggregate state
+        // across the window. Holding them stalls Pulsar sources once in-flight unacked hits
+        // max_unacked_messages_per_consumer. RocksDB state persistence provides durability.
+        event
+            .take_finalizers()
+            .update_status(EventStatus::Delivered);
+
         let event_key = self.get_event_key(&event);
         let event_timestamp = self.get_event_timestamp(&event);
 
@@ -457,18 +464,7 @@ impl MezmoAggregateV2 {
             match handle {
                 Ok(result) => match result {
                     Ok(_) => {
-                        // LOG-19818: Many usages of the aggregate processor span a time boundary that
-                        // causes heartburn with kafka acknowledgements. If we've persisted the data
-                        // locally, then update the status on the finalizers as delivered; the processor
-                        // will now provide the durability.
-                        for windows in self.data.values_mut() {
-                            for window in windows.iter_mut() {
-                                window
-                                    .event
-                                    .take_finalizers()
-                                    .update_status(EventStatus::Delivered);
-                            }
-                        }
+                        // Finalizers are acked on receipt in `record`; nothing to release here.
                         debug!("MezmoAggregateV2: state persisted");
                     }
                     Err(err) => {

--- a/src/transforms/reduce/mezmo_reduce.rs
+++ b/src/transforms/reduce/mezmo_reduce.rs
@@ -739,6 +739,14 @@ impl MezmoReduce {
     fn transform_one(&mut self, output: &mut Vec<Event>, event: Event) {
         let mut event = event.into_log();
 
+        // Ack the source event on receipt rather than holding its finalizers in reduce state
+        // across the window. Holding them stalls Pulsar sources once in-flight unacked hits
+        // max_unacked_messages_per_consumer. RocksDB state persistence provides durability.
+        event
+            .metadata_mut()
+            .take_finalizers()
+            .update_status(vector_lib::event::EventStatus::Delivered);
+
         // Mezmo functionality here creates a new Event with the `.message` properties moved
         // to the root of the new event. This way, we can reuse all the complex functionality
         // of Condition and whether or not the reduce accumulator should stop, and how group_by works.
@@ -805,15 +813,7 @@ impl MezmoReduce {
             );
             match persist_runtime_state(state, state_persistence).await {
                 Ok(_) => {
-                    // Once persisted, update the status on the finalizers as delivered thus acking the
-                    // original events. RocksDB will provide the durability of the aggregate events.
-                    for reduce in self.reduce_merge_states.values_mut() {
-                        reduce
-                            .metadata
-                            .take_finalizers()
-                            .update_status(vector_lib::event::EventStatus::Delivered);
-                    }
-
+                    // Finalizers are acked on receipt in `transform_one`; nothing to release here.
                     debug!("MezmoReduce: persisted state successfully");
                 }
                 Err(err) => {


### PR DESCRIPTION
When using RocksDB, holding onto finalizers while waiting 30s to flush prevents acking from working in Pulsar. The effect of this is completely stalled pipelines since Pulsar will stop sending messages if acking is slow (in terms of "max unacked" settings). This commit takes the finalizers earlier in the process to prevent the statefulness from causing ack stalls.

Ref: LOG-24001

