### PR TITLE
fix(source): http source should gracefully fail

### DIFF
--- a/src/internal_events/http_client_source.rs
+++ b/src/internal_events/http_client_source.rs
@@ -64,6 +64,31 @@ impl InternalEvent for HttpClientHttpResponseError {
 }
 
 #[derive(Debug, NamedInternalEvent)]
+pub struct HttpClientBuildError {
+    pub error: http::Error,
+    pub url: String,
+}
+
+impl InternalEvent for HttpClientBuildError {
+    fn emit(self) {
+        error!(
+            message = "Failed to build HTTP request; skipping.",
+            url = %self.url,
+            error = ?self.error,
+            error_type = error_type::REQUEST_FAILED,
+            stage = error_stage::PROCESSING,
+        );
+        counter!(
+            "component_errors_total",
+            "url" => self.url,
+            "error_type" => error_type::REQUEST_FAILED,
+            "stage" => error_stage::PROCESSING,
+        )
+        .increment(1);
+    }
+}
+
+#[derive(Debug, NamedInternalEvent)]
 pub struct HttpClientHttpError {
     pub error: crate::Error,
     pub url: String,

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -27,7 +27,7 @@ use crate::{
     SourceSender,
     http::{Auth, HttpClient, QueryParameterValue, QueryParameters},
     internal_events::{
-        EndpointBytesReceived, HttpClientEventsReceived, HttpClientHttpError,
+        EndpointBytesReceived, HttpClientBuildError, HttpClientEventsReceived, HttpClientHttpError,
         HttpClientHttpResponseError, StreamClosedError,
     },
     sources::util::http::HttpMethod,
@@ -211,8 +211,20 @@ pub(crate) async fn call<
                 None => Body::empty(),
             };
 
-            // building the request should be infallible
-            let mut request = builder.body(body).expect("error creating request");
+            // Building the request can fail if a user-supplied header name/value
+            // or the URL is invalid (for example control characters or CRLF in a
+            // header value). Skip this request instead of panicking, which would
+            // crash the entire (shared) Vector process.
+            let mut request = match builder.body(body) {
+                Ok(request) => request,
+                Err(error) => {
+                    emit!(HttpClientBuildError {
+                        error,
+                        url: url.to_string(),
+                    });
+                    return stream::empty::<Event>().boxed();
+                }
+            };
 
             if let Some(auth) = &inputs.auth {
                 auth.apply(&mut request);


### PR DESCRIPTION
If the source fails to build (due to invalid headers, for example) it should be skipped so that the entire vector instance doesn't crash.

Ref: LOG-24045


