### PR TITLE
fix(vrl): Disallow vrl functions used in SSRF attacks

### DIFF
--- a/lib/mezmo/src/functions/mod.rs
+++ b/lib/mezmo/src/functions/mod.rs
@@ -8,6 +8,17 @@ pub mod user_log;
 #[cfg(test)]
 pub(crate) mod test_util;
 
+/// VRL functions disabled in the Mezmo Vector build. Some of these can be used
+/// in attack vectors for SSRF. See VM-673.
+pub const DISABLED_VRL_FUNCTIONS: &[&str] = &["http_request", "dns_lookup"];
+
+/// Removes the Mezmo-disabled functions ([`DISABLED_VRL_FUNCTIONS`]) from a compiler
+/// function set. Call after assembling `vrl::stdlib::all()` + extensions at every VRL
+/// compile site.
+pub fn remove_disabled(functions: &mut Vec<Box<dyn Function>>) {
+    functions.retain(|f| !DISABLED_VRL_FUNCTIONS.contains(&f.identifier()));
+}
+
 pub fn vrl_functions() -> Vec<Box<dyn Function>> {
     vec![
         Box::new(user_log::UserLog) as _,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -377,6 +377,8 @@ impl SubCommand {
                 let mut functions = vrl::stdlib::all();
                 functions.extend(vector_vrl_functions::all());
                 functions.extend(mezmo::functions::cli_vrl_functions());
+                // VM-673: strip SSRF-capable functions.
+                mezmo::functions::remove_disabled(&mut functions);
                 vrl::cli::cmd::cmd(s, functions)
             }
         }

--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -144,11 +144,13 @@ impl HttpServerAuthConfig {
                 ))
             }
             HttpServerAuthConfig::Custom { source } => {
-                let functions = vrl::stdlib::all()
+                let mut functions = vrl::stdlib::all()
                     .into_iter()
                     .chain(vector_lib::enrichment::vrl_functions())
                     .chain(vector_vrl_functions::all())
                     .collect::<Vec<_>>();
+                // VM-673: strip SSRF-capable functions.
+                mezmo::functions::remove_disabled(&mut functions);
 
                 let state = TypeState::default();
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -237,6 +237,8 @@ impl RemapConfig {
         functions.append(&mut dnstap_parser::vrl_functions());
         functions.append(&mut vector_vrl_functions::all());
         functions.append(&mut mezmo_vrl_functions::vrl_functions());
+        // VM-673: strip SSRF-capable functions from the set.
+        mezmo_vrl_functions::remove_disabled(&mut functions);
 
         let state = TypeState {
             local: Default::default(),


### PR DESCRIPTION
Certain functions in vrl, namely `http_request` and `dns_lookup` can be used in SSRF forgeries and probably other attacks. Disallow these functions to be used in vrl.

Ref: VM-673

