### PR TITLE
feat(new_relic): add support for Traces API

### DIFF
--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -39,6 +39,9 @@ pub enum NewRelicApi {
 
     /// Logs API.
     Logs,
+
+    /// Traces API.
+    Traces,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -211,6 +214,12 @@ impl NewRelicCredentials {
             NewRelicApi::Logs => match self.region {
                 NewRelicRegion::Us => Uri::from_static("https://log-api.newrelic.com/log/v1"),
                 NewRelicRegion::Eu => Uri::from_static("https://log-api.eu.newrelic.com/log/v1"),
+            },
+            NewRelicApi::Traces => match self.region {
+                NewRelicRegion::Us => Uri::from_static("https://trace-api.newrelic.com/trace/v1"),
+                NewRelicRegion::Eu => {
+                    Uri::from_static("https://trace-api.eu.newrelic.com/trace/v1")
+                }
             },
         }
     }

--- a/src/sinks/new_relic/encoding.rs
+++ b/src/sinks/new_relic/encoding.rs
@@ -8,7 +8,7 @@ use vector_lib::{
 
 use super::{
     EventsApiModel, LogsApiModel, MetricsApiModel, NewRelicApi, NewRelicApiModel,
-    NewRelicCredentials, NewRelicSinkError,
+    NewRelicCredentials, NewRelicSinkError, TracesApiModel,
 };
 use crate::sinks::{
     prelude::*,
@@ -37,12 +37,14 @@ impl Encoder<Vec<Event>> for NewRelicEncoder {
             NewRelicApi::Events => NewRelicApiModel::Events(EventsApiModel::try_from(input)?),
             NewRelicApi::Metrics => NewRelicApiModel::Metrics(MetricsApiModel::try_from(input)?),
             NewRelicApi::Logs => NewRelicApiModel::Logs(LogsApiModel::try_from(input)?),
+            NewRelicApi::Traces => NewRelicApiModel::Traces(TracesApiModel::try_from(input)?),
         };
 
         let json = match api_model {
             NewRelicApiModel::Events(ev_api_model) => to_json(&ev_api_model)?,
             NewRelicApiModel::Metrics(met_api_model) => to_json(&met_api_model)?,
             NewRelicApiModel::Logs(log_api_model) => to_json(&log_api_model)?,
+            NewRelicApiModel::Traces(traces_api_model) => to_json(&traces_api_model)?,
         };
 
         let size = as_tracked_write::<_, _, io::Error>(writer, &json, |writer, json| {

--- a/src/sinks/new_relic/healthcheck.rs
+++ b/src/sinks/new_relic/healthcheck.rs
@@ -2,17 +2,29 @@ use std::sync::Arc;
 
 use http::Request;
 
-use super::NewRelicCredentials;
+use super::{NewRelicApi, NewRelicCredentials};
 use crate::{http::HttpClient, sinks::HealthcheckError};
 
 pub(crate) async fn healthcheck(
     client: HttpClient,
     credentials: Arc<NewRelicCredentials>,
 ) -> crate::Result<()> {
-    let request = Request::post(credentials.get_uri())
-        .header("Api-Key", credentials.license_key.clone())
-        .body(hyper::Body::empty())
-        .unwrap();
+    // The Events/Metrics/Logs ingest APIs accept an empty POST body for a connectivity/auth check.
+    // The Trace API rejects an empty body, so send a minimal valid (empty) trace payload with the
+    // required format headers instead.
+    let request = match credentials.api {
+        NewRelicApi::Traces => Request::post(credentials.get_uri())
+            .header("Api-Key", credentials.license_key.clone())
+            .header("Content-Type", "application/json")
+            .header("Data-Format", "newrelic")
+            .header("Data-Format-Version", "1")
+            .body(hyper::Body::from(r#"[{"spans":[]}]"#))
+            .unwrap(),
+        _ => Request::post(credentials.get_uri())
+            .header("Api-Key", credentials.license_key.clone())
+            .body(hyper::Body::empty())
+            .unwrap(),
+    };
 
     let response = client.send(request).await?;
 

--- a/src/sinks/new_relic/model.rs
+++ b/src/sinks/new_relic/model.rs
@@ -9,19 +9,20 @@ use ordered_float::NotNan;
 use serde::Serialize;
 use vector_lib::{
     config::log_schema,
-    event::ObjectMap,
+    event::{KeyString, ObjectMap},
     internal_event::{ComponentEventsDropped, INTENTIONAL, UNINTENTIONAL},
 };
 use vrl::event_path;
 
 use super::NewRelicSinkError;
-use crate::event::{Event, MetricKind, MetricValue, Value};
+use crate::event::{Event, LogEvent, MetricKind, MetricValue, Value};
 
 #[derive(Debug)]
 pub(super) enum NewRelicApiModel {
     Metrics(MetricsApiModel),
     Events(EventsApiModel),
     Logs(LogsApiModel),
+    Traces(TracesApiModel),
 }
 
 /// The metrics API data model.
@@ -333,6 +334,340 @@ impl TryFrom<Vec<Event>> for LogsApiModel {
         } else {
             Err(NewRelicSinkError::new("No valid logs to generate"))
         }
+    }
+}
+
+/// The Trace API data model, using the New Relic-format trace payload.
+///
+/// Reference: https://docs.newrelic.com/docs/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api/
+#[derive(Debug, Serialize)]
+pub(super) struct TracesApiModel(pub [SpanStore; 1]);
+
+#[derive(Debug, Serialize)]
+pub(super) struct SpanStore {
+    pub spans: Vec<Span>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct Span {
+    #[serde(rename = "trace.id")]
+    pub trace_id: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<i64>,
+    pub attributes: ObjectMap,
+}
+
+impl TracesApiModel {
+    pub(super) const fn new(spans: Vec<Span>) -> Self {
+        Self([SpanStore { spans }])
+    }
+}
+
+const NANOS_PER_MILLI_F64: f64 = 1_000_000.0;
+const NANOS_PER_MILLI: i64 = 1_000_000;
+const OTEL_STATUS_CODE_ERROR: i64 = 2;
+
+/// Attribute keys that New Relic drops or that trigger undefined behavior. Stripped from any
+/// passthrough attributes.
+///
+/// Reference: https://docs.newrelic.com/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits/
+const RESTRICTED_TRACE_ATTRIBUTES: [&str; 5] = [
+    "entityGuid",
+    "guid",
+    "entity.guid",
+    "entity.name",
+    "entity.type",
+];
+
+/// Why a span envelope was dropped during translation. Determines which `ComponentEventsDropped`
+/// internal event is emitted.
+enum SpanDropReason {
+    NonObject,
+    NonTrace,
+    MissingId,
+    MissingStart,
+}
+
+impl TryFrom<Vec<Event>> for TracesApiModel {
+    type Error = NewRelicSinkError;
+
+    fn try_from(buf_events: Vec<Event>) -> Result<Self, Self::Error> {
+        let mut num_non_log = 0;
+        let mut num_non_object = 0;
+        let mut num_non_trace = 0;
+        let mut num_missing_id = 0;
+        let mut num_missing_start = 0;
+
+        let spans: Vec<Span> = buf_events
+            .into_iter()
+            .filter_map(|event| {
+                let Some(log) = event.try_into_log() else {
+                    num_non_log += 1;
+                    return None;
+                };
+                match span_from_log(log) {
+                    Ok(span) => Some(span),
+                    Err(SpanDropReason::NonObject) => {
+                        num_non_object += 1;
+                        None
+                    }
+                    Err(SpanDropReason::NonTrace) => {
+                        num_non_trace += 1;
+                        None
+                    }
+                    Err(SpanDropReason::MissingId) => {
+                        num_missing_id += 1;
+                        None
+                    }
+                    Err(SpanDropReason::MissingStart) => {
+                        num_missing_start += 1;
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        if num_non_log > 0 {
+            emit!(ComponentEventsDropped::<INTENTIONAL> {
+                count: num_non_log,
+                reason: "non-log event",
+            });
+        }
+        if num_non_object > 0 {
+            emit!(ComponentEventsDropped::<INTENTIONAL> {
+                count: num_non_object,
+                reason: "non-object event",
+            });
+        }
+        if num_non_trace > 0 {
+            emit!(ComponentEventsDropped::<INTENTIONAL> {
+                count: num_non_trace,
+                reason: "non-trace event",
+            });
+        }
+        if num_missing_id > 0 {
+            emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                count: num_missing_id,
+                reason: "span missing trace/span id",
+            });
+        }
+        if num_missing_start > 0 {
+            emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                count: num_missing_start,
+                reason: "span missing start time",
+            });
+        }
+
+        if !spans.is_empty() {
+            Ok(Self::new(spans))
+        } else {
+            Err(NewRelicSinkError::new("No valid spans to generate"))
+        }
+    }
+}
+
+/// Translate a single span envelope (`{resource, scope, type, record}`) log into a New Relic
+/// trace span. Reserved attributes are written after passthrough attributes so they win on any
+/// key collision.
+fn span_from_log(mut log: LogEvent) -> Result<Span, SpanDropReason> {
+    // Mezmo pipeline events wrap the self-describing span envelope under the log schema message
+    // key (`{message: {record, resource, scope, type}}`). Prefer that payload; fall back to the
+    // event root for a bare root-level envelope.
+    let mut envelope = match take_message_object(&mut log) {
+        Some(message) => message,
+        None => log
+            .into_parts()
+            .0
+            .into_object()
+            .ok_or(SpanDropReason::NonObject)?,
+    };
+
+    // The envelope carries `type: "trace"`. Reject other types when the field is present, but
+    // tolerate its absence.
+    if let Some(kind) = envelope.get("type").and_then(Value::as_str)
+        && &*kind != "trace"
+    {
+        return Err(SpanDropReason::NonTrace);
+    }
+
+    let mut record = envelope
+        .remove("record")
+        .and_then(Value::into_object)
+        .ok_or(SpanDropReason::MissingId)?;
+
+    let trace_id = take_id(&mut record, "traceId").ok_or(SpanDropReason::MissingId)?;
+    let id = take_id(&mut record, "spanId").ok_or(SpanDropReason::MissingId)?;
+
+    let start_ns = record
+        .remove("startTimeUnixNano")
+        .as_ref()
+        .and_then(parse_unix_nanos)
+        .filter(|&ns| ns > 0)
+        .ok_or(SpanDropReason::MissingStart)?;
+    let end_ns = record
+        .remove("endTimeUnixNano")
+        .as_ref()
+        .and_then(parse_unix_nanos);
+    let duration_ms = end_ns
+        .map(|end| ((end - start_ns) as f64 / NANOS_PER_MILLI_F64).max(0.0))
+        .unwrap_or(0.0);
+
+    let mut attributes = ObjectMap::new();
+
+    // Passthrough: resource attributes (lowest priority). `service.name` is promoted to a
+    // reserved attribute; restricted keys are stripped.
+    let mut service_name = None;
+    if let Some(mut resource) = envelope.remove("resource").and_then(Value::into_object)
+        && let Some(resource_attributes) =
+            resource.remove("attributes").and_then(Value::into_object)
+    {
+        for (key, value) in resource_attributes {
+            if key.as_str() == "service.name" {
+                service_name = coerce_attribute_value(value);
+                continue;
+            }
+            insert_passthrough_attribute(&mut attributes, key, value);
+        }
+    }
+
+    // Passthrough: span attributes (override resource attributes on collision).
+    if let Some(span_attributes) = record.remove("attributes").and_then(Value::into_object) {
+        for (key, value) in span_attributes {
+            insert_passthrough_attribute(&mut attributes, key, value);
+        }
+    }
+
+    // Reserved attributes.
+    attributes.insert("duration.ms".into(), Value::from_f64_or_zero(duration_ms));
+    if let Some(name) = record.remove("name").filter(|v| !v.is_null()) {
+        attributes.insert("name".into(), name);
+    }
+    if let Some(parent_id) = record.remove("parentSpanId").filter(|v| !v.is_null()) {
+        attributes.insert("parent.id".into(), parent_id);
+    }
+    if let Some(service_name) = service_name {
+        attributes.insert("service.name".into(), service_name);
+    }
+    if let Some(kind) = record.remove("kind").as_ref().and_then(Value::as_integer)
+        && let Some(kind) = map_span_kind(kind)
+    {
+        attributes.insert("span.kind".into(), Value::from(kind));
+    }
+    if let Some(mut status) = record.remove("status").and_then(Value::into_object) {
+        if let Some(code) = status.remove("code").as_ref().and_then(Value::as_integer) {
+            attributes.insert(
+                "otel.status_code".into(),
+                Value::from(map_status_code(code)),
+            );
+            if code == OTEL_STATUS_CODE_ERROR {
+                attributes.insert("error".into(), Value::from(true));
+            }
+        }
+        if let Some(message) = status.remove("message").filter(|v| !v.is_null()) {
+            attributes.insert("otel.status_description".into(), message);
+        }
+    }
+    if let Some(mut scope) = envelope.remove("scope").and_then(Value::into_object) {
+        if let Some(name) = scope.remove("name").filter(|v| !v.is_null()) {
+            attributes.insert("otel.scope.name".into(), name);
+        }
+        if let Some(version) = scope.remove("version").filter(|v| !v.is_null()) {
+            attributes.insert("otel.scope.version".into(), version);
+        }
+    }
+    if let Some(events) = record.remove("events").filter(|v| !v.is_null())
+        && let Ok(json) = serde_json::to_string(&events)
+    {
+        attributes.insert("otel.span.events".into(), Value::from(json));
+    }
+    if let Some(links) = record.remove("links").filter(|v| !v.is_null())
+        && let Ok(json) = serde_json::to_string(&links)
+    {
+        attributes.insert("otel.span.links".into(), Value::from(json));
+    }
+
+    Ok(Span {
+        trace_id,
+        id,
+        timestamp: Some(start_ns / NANOS_PER_MILLI),
+        attributes,
+    })
+}
+
+fn insert_passthrough_attribute(attributes: &mut ObjectMap, key: KeyString, value: Value) {
+    if is_restricted_trace_attribute(key.as_str()) {
+        return;
+    }
+    if let Some(value) = coerce_attribute_value(value) {
+        attributes.insert(key, value);
+    }
+}
+
+/// Remove and return the span envelope when the event wraps it under the log schema message key
+/// (`{message: {record, ...}}`), the shape Mezmo pipeline events use. Returns `None` when there is
+/// no message object, so the caller falls back to treating the event root as the envelope.
+fn take_message_object(log: &mut LogEvent) -> Option<ObjectMap> {
+    let path = log_schema().message_key_target_path()?;
+    log.remove(path).and_then(Value::into_object)
+}
+
+/// Remove a hex-string id (`traceId`/`spanId`) from the record, returning `None` when absent,
+/// empty, or not a string.
+fn take_id(record: &mut ObjectMap, key: &str) -> Option<String> {
+    match record.remove(key) {
+        Some(Value::Bytes(bytes)) => {
+            let id = String::from_utf8_lossy(bytes.as_ref()).into_owned();
+            (!id.is_empty()).then_some(id)
+        }
+        _ => None,
+    }
+}
+
+/// Parse a `*UnixNano` value. The decoder keeps these as strings to preserve int64 precision, but
+/// tolerate integers/floats as well.
+fn parse_unix_nanos(value: &Value) -> Option<i64> {
+    match value {
+        Value::Bytes(bytes) => String::from_utf8_lossy(bytes.as_ref()).trim().parse().ok(),
+        Value::Integer(n) => Some(*n),
+        Value::Float(f) => Some(f.into_inner() as i64),
+        _ => None,
+    }
+}
+
+/// Map an OTel `SpanKind` integer to the New Relic `span.kind` string. `0` (unspecified) is
+/// omitted.
+const fn map_span_kind(kind: i64) -> Option<&'static str> {
+    match kind {
+        1 => Some("internal"),
+        2 => Some("server"),
+        3 => Some("client"),
+        4 => Some("producer"),
+        5 => Some("consumer"),
+        _ => None,
+    }
+}
+
+const fn map_status_code(code: i64) -> &'static str {
+    match code {
+        1 => "OK",
+        2 => "ERROR",
+        _ => "UNSET",
+    }
+}
+
+fn is_restricted_trace_attribute(key: &str) -> bool {
+    RESTRICTED_TRACE_ATTRIBUTES.contains(&key)
+}
+
+/// Coerce an attribute value to a New Relic trace attribute (string/number/boolean). Arrays and
+/// objects are JSON-stringified; nulls drop the key.
+fn coerce_attribute_value(value: Value) -> Option<Value> {
+    match value {
+        Value::Bytes(_) | Value::Integer(_) | Value::Float(_) | Value::Boolean(_) => Some(value),
+        Value::Array(_) | Value::Object(_) => serde_json::to_string(&value).ok().map(Value::from),
+        Value::Null => None,
+        other => Some(other),
     }
 }
 

--- a/src/sinks/new_relic/service.rs
+++ b/src/sinks/new_relic/service.rs
@@ -12,7 +12,7 @@ use http::{
 use hyper::Body;
 use tracing::Instrument;
 
-use super::{NewRelicCredentials, NewRelicSinkError};
+use super::{NewRelicApi, NewRelicCredentials, NewRelicSinkError};
 use crate::{
     http::HttpClient,
     sinks::{prelude::*, util::Compression},
@@ -85,6 +85,15 @@ impl Service<NewRelicApiRequest> for NewRelicApiService {
         let http_request = Request::post(&uri)
             .header(CONTENT_TYPE, "application/json")
             .header("Api-Key", request.credentials.license_key.clone());
+
+        // The Trace API requires the payload format to be declared explicitly.
+        let http_request = if request.credentials.api == NewRelicApi::Traces {
+            http_request
+                .header("Data-Format", "newrelic")
+                .header("Data-Format-Version", "1")
+        } else {
+            http_request
+        };
 
         let http_request = if let Some(ce) = request.compression.content_encoding() {
             http_request.header(CONTENT_ENCODING, ce)

--- a/src/sinks/new_relic/tests.rs
+++ b/src/sinks/new_relic/tests.rs
@@ -314,3 +314,451 @@ fn generates_metric_api_model_incremental_counter() {
         }])
     );
 }
+
+/// A full span envelope matching the ingestion-service sample, used by the happy-path model test
+/// and the trace component-spec compliance test.
+fn sample_trace_event() -> Event {
+    Event::Log(LogEvent::from(value!({
+        "resource": {
+            "attributes": {
+                "service.name": "webapp",
+                "host.name": "ldw-5dbcfb759c-jrwmp",
+                "host.arch": "amd64",
+                "process.pid": 1,
+                "process.command_args": ["/usr/local/bin/node", "/opt/app/apps/api/src/webapp.js"],
+                "service.version": "16.1.33",
+            }
+        },
+        "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.57.0",
+            "attributes": {},
+        },
+        "type": "trace",
+        "record": {
+            "traceId": "30d23cf53e9f28f2e22f03d8e62e9a75",
+            "spanId": "1a5d223c717ed91a",
+            "parentSpanId": "3d6e9066774f0aed",
+            "name": "middleware - i18nextMiddleware",
+            "kind": 1,
+            "startTimeUnixNano": "1783696528282000000",
+            "endTimeUnixNano": "1783696528282252457",
+            "attributes": {
+                "express.name": "i18nextMiddleware",
+                "express.type": "middleware",
+            },
+            "status": { "code": 0 },
+            "droppedAttributesCount": 0,
+            "droppedEventsCount": 0,
+            "droppedLinksCount": 0,
+        },
+    })))
+}
+
+fn trace_attributes(model: &TracesApiModel) -> serde_json::Value {
+    to_value(&model.0[0].spans[0].attributes).unwrap()
+}
+
+#[test]
+fn generates_trace_api_model_happy_path() {
+    let model = TracesApiModel::try_from(vec![sample_trace_event()])
+        .expect("Failed mapping trace into API model");
+
+    assert_eq!(
+        to_value(&model).unwrap(),
+        json!([{
+            "spans": [{
+                "trace.id": "30d23cf53e9f28f2e22f03d8e62e9a75",
+                "id": "1a5d223c717ed91a",
+                "timestamp": 1_783_696_528_282i64,
+                "attributes": {
+                    "duration.ms": 0.252457,
+                    "name": "middleware - i18nextMiddleware",
+                    "parent.id": "3d6e9066774f0aed",
+                    "service.name": "webapp",
+                    "span.kind": "internal",
+                    "otel.status_code": "UNSET",
+                    "express.name": "i18nextMiddleware",
+                    "express.type": "middleware",
+                    "host.name": "ldw-5dbcfb759c-jrwmp",
+                    "host.arch": "amd64",
+                    "process.pid": 1,
+                    "process.command_args": "[\"/usr/local/bin/node\",\"/opt/app/apps/api/src/webapp.js\"]",
+                    "service.version": "16.1.33",
+                    "otel.scope.name": "@opentelemetry/instrumentation-express",
+                    "otel.scope.version": "0.57.0",
+                }
+            }]
+        }])
+    );
+}
+
+#[test]
+fn generates_trace_api_model_from_message_wrapped_envelope() {
+    // Real Mezmo pipeline shape: the span envelope is nested under `message`, alongside unrelated
+    // root-level fields (timestamp/metadata/annotations) that must be ignored.
+    let event = Event::Log(LogEvent::from(value!({
+        "timestamp": "2026-07-15T14:43:37.709+00:00",
+        "metadata": {"headers": {}, "query": {}},
+        "annotations": {"app": "pipeline-service"},
+        "message": {
+            "resource": {"attributes": {
+                "service.name": "pipeline-service",
+                "host.name": "ip-10-30-30-239.ec2.internal",
+            }},
+            "scope": {
+                "name": "@opentelemetry/instrumentation-pg",
+                "version": "0.71.0",
+                "attributes": {},
+            },
+            "type": "trace",
+            "record": {
+                "traceId": "9c5d5196ae3067ceefc8f125b9108cc3",
+                "spanId": "0ae6f4b8542655cf",
+                "parentSpanId": "822e8b7fd5656f48",
+                "name": "pg-pool.connect",
+                "kind": 3,
+                "startTimeUnixNano": "1784126617709000000",
+                "endTimeUnixNano": "1784126617709064969",
+                "attributes": {"db.system": "postgresql", "net.peer.port": 5432},
+                "status": {"code": 0},
+            },
+        },
+    })));
+    let model = TracesApiModel::try_from(vec![event]).expect("Failed mapping trace into API model");
+
+    assert_eq!(
+        to_value(&model).unwrap(),
+        json!([{
+            "spans": [{
+                "trace.id": "9c5d5196ae3067ceefc8f125b9108cc3",
+                "id": "0ae6f4b8542655cf",
+                "timestamp": 1_784_126_617_709i64,
+                "attributes": {
+                    "duration.ms": 0.064969,
+                    "name": "pg-pool.connect",
+                    "parent.id": "822e8b7fd5656f48",
+                    "service.name": "pipeline-service",
+                    "span.kind": "client",
+                    "otel.status_code": "UNSET",
+                    "host.name": "ip-10-30-30-239.ec2.internal",
+                    "db.system": "postgresql",
+                    "net.peer.port": 5432,
+                    "otel.scope.name": "@opentelemetry/instrumentation-pg",
+                    "otel.scope.version": "0.71.0",
+                }
+            }]
+        }])
+    );
+}
+
+#[test]
+fn generates_trace_api_model_timestamp_and_duration() {
+    let event = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5002500000",
+        },
+    })));
+    let model = TracesApiModel::try_from(vec![event]).expect("Failed mapping trace into API model");
+
+    let span = &model.0[0].spans[0];
+    assert_eq!(span.timestamp, Some(5000));
+    assert_eq!(trace_attributes(&model)["duration.ms"], json!(2.5));
+}
+
+#[test]
+fn trace_api_model_omits_parent_id_for_root_span() {
+    let event = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5000000000",
+        },
+    })));
+    let model = TracesApiModel::try_from(vec![event]).expect("Failed mapping trace into API model");
+
+    assert!(trace_attributes(&model).get("parent.id").is_none());
+}
+
+#[test]
+fn trace_api_model_clamps_negative_duration() {
+    let event = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "4000000000",
+        },
+    })));
+    let model = TracesApiModel::try_from(vec![event]).expect("Failed mapping trace into API model");
+
+    assert_eq!(trace_attributes(&model)["duration.ms"], json!(0.0));
+}
+
+#[test]
+fn trace_api_model_drops_span_missing_ids() {
+    let missing_trace_id = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+        },
+    })));
+    assert!(TracesApiModel::try_from(vec![missing_trace_id]).is_err());
+
+    let missing_span_id = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "startTimeUnixNano": "5000000000",
+        },
+    })));
+    assert!(TracesApiModel::try_from(vec![missing_span_id]).is_err());
+}
+
+#[test]
+fn trace_api_model_drops_span_missing_or_zero_start() {
+    let zero_start = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "0",
+        },
+    })));
+    assert!(TracesApiModel::try_from(vec![zero_start]).is_err());
+
+    let absent_start = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+        },
+    })));
+    assert!(TracesApiModel::try_from(vec![absent_start]).is_err());
+}
+
+#[test]
+fn trace_api_model_maps_error_status() {
+    let event = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5000000000",
+            "status": { "code": 2, "message": "boom" },
+        },
+    })));
+    let model = TracesApiModel::try_from(vec![event]).expect("Failed mapping trace into API model");
+
+    let attributes = trace_attributes(&model);
+    assert_eq!(attributes["otel.status_code"], json!("ERROR"));
+    assert_eq!(attributes["otel.status_description"], json!("boom"));
+    assert_eq!(attributes["error"], json!(true));
+}
+
+#[test]
+fn trace_api_model_maps_span_kind() {
+    let server = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5000000000",
+            "kind": 2,
+        },
+    })));
+    let model =
+        TracesApiModel::try_from(vec![server]).expect("Failed mapping trace into API model");
+    assert_eq!(trace_attributes(&model)["span.kind"], json!("server"));
+
+    let unspecified = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5000000000",
+            "kind": 0,
+        },
+    })));
+    let model =
+        TracesApiModel::try_from(vec![unspecified]).expect("Failed mapping trace into API model");
+    assert!(trace_attributes(&model).get("span.kind").is_none());
+}
+
+#[test]
+fn trace_api_model_stringifies_events_and_links() {
+    let event = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5000000000",
+            "events": [{ "name": "exception", "timeUnixNano": "5000000001" }],
+            "links": [{ "traceId": "cccc", "spanId": "dddd" }],
+        },
+    })));
+    let model = TracesApiModel::try_from(vec![event]).expect("Failed mapping trace into API model");
+
+    let attributes = trace_attributes(&model);
+    assert_eq!(
+        attributes["otel.span.events"],
+        json!("[{\"name\":\"exception\",\"timeUnixNano\":\"5000000001\"}]")
+    );
+    assert_eq!(
+        attributes["otel.span.links"],
+        json!("[{\"spanId\":\"dddd\",\"traceId\":\"cccc\"}]")
+    );
+}
+
+#[test]
+fn trace_api_model_strips_restricted_attributes() {
+    let event = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "resource": {
+            "attributes": {
+                "entityGuid": "resource-guid",
+                "kept": "resource-value",
+            }
+        },
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5000000000",
+            "attributes": {
+                "guid": "x",
+                "entity.guid": "y",
+                "entity.name": "z",
+                "entity.type": "w",
+                "kept.span": "span-value",
+            },
+        },
+    })));
+    let model = TracesApiModel::try_from(vec![event]).expect("Failed mapping trace into API model");
+
+    let attributes = trace_attributes(&model);
+    for restricted in [
+        "entityGuid",
+        "guid",
+        "entity.guid",
+        "entity.name",
+        "entity.type",
+    ] {
+        assert!(
+            attributes.get(restricted).is_none(),
+            "restricted attribute {restricted} should be stripped"
+        );
+    }
+    assert_eq!(attributes["kept"], json!("resource-value"));
+    assert_eq!(attributes["kept.span"], json!("span-value"));
+}
+
+#[test]
+fn trace_api_model_combines_multiple_spans() {
+    let first = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "1111",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5000000000",
+        },
+    })));
+    let second = Event::Log(LogEvent::from(value!({
+        "type": "trace",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "2222",
+            "startTimeUnixNano": "5000000000",
+            "endTimeUnixNano": "5000000000",
+        },
+    })));
+    let model = TracesApiModel::try_from(vec![first, second])
+        .expect("Failed mapping traces into API model");
+
+    let value = to_value(&model).unwrap();
+    assert_eq!(value.as_array().unwrap().len(), 1);
+    assert_eq!(value[0]["spans"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn trace_api_model_drops_non_trace_event() {
+    let non_trace = Event::Log(LogEvent::from(value!({
+        "type": "log",
+        "record": {
+            "traceId": "aaaa",
+            "spanId": "bbbb",
+            "startTimeUnixNano": "5000000000",
+        },
+    })));
+    assert!(TracesApiModel::try_from(vec![non_trace]).is_err());
+}
+
+#[test]
+fn trace_api_model_drops_non_log_event() {
+    let metric = Event::Metric(Metric::new(
+        "my_metric",
+        MetricKind::Absolute,
+        MetricValue::Counter { value: 100.0 },
+    ));
+    assert!(TracesApiModel::try_from(vec![metric]).is_err());
+}
+
+#[test]
+fn trace_endpoints_resolve_by_region() {
+    let base = NewRelicCredentials {
+        license_key: "key".to_owned(),
+        account_id: "123".to_owned(),
+        api: NewRelicApi::Traces,
+        region: NewRelicRegion::Us,
+        override_uri: None,
+    };
+    assert_eq!(
+        base.get_uri().to_string(),
+        "https://trace-api.newrelic.com/trace/v1"
+    );
+
+    let eu = NewRelicCredentials {
+        region: NewRelicRegion::Eu,
+        ..base
+    };
+    assert_eq!(
+        eu.get_uri().to_string(),
+        "https://trace-api.eu.newrelic.com/trace/v1"
+    );
+}
+
+async fn trace_sink() -> (VectorSink, Event) {
+    let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
+
+    let config = NewRelicConfig::generate_config().to_string();
+    let mut config = NewRelicConfig::deserialize(
+        toml::de::ValueDeserializer::parse(&config).expect("toml should deserialize"),
+    )
+    .expect("config should be valid");
+    config.api = NewRelicApi::Traces;
+    config.override_uri = Some(mock_endpoint);
+
+    let context = SinkContext::default();
+    let (sink, _healthcheck) = config.build(context).await.unwrap();
+
+    (sink, sample_trace_event())
+}
+
+#[tokio::test]
+async fn component_spec_compliance_traces() {
+    let (sink, event) = trace_sink().await;
+    run_and_assert_sink_compliance(sink, stream::once(ready(event)), &SINK_TAGS).await;
+}


### PR DESCRIPTION
Adds support to the existing New Relic sink for sending traces from our combined OpenTelemetry source (in our internal format) to the New Relic Traces API.

This reuses the existing request service and
batching/compression machinery, rather than introducing any attribute-level batching. This means each outgoing span includes all of the attributes and there is no deduping into a top-level `common` set, which trades outbound payload size for simpler batching.

Ref: LOG-24120

