### PR TITLE
fix(http_client source): Block internal addresses at resolve time

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -40,6 +40,7 @@ use crate::{
     config::ProxyConfig,
     internal_events::{HttpServerRequestReceived, HttpServerResponseSent, http_client},
     mezmo::user_trace::UserLoggingError,
+    ssrf::GuardedResolver,
     tls::{MaybeTlsSettings, TlsError, tls_connector_builder},
 };
 
@@ -62,17 +63,38 @@ pub enum HttpError {
     CallRequest { source: hyper::Error },
     #[snafu(display("Failed to build HTTP request: {}", source))]
     BuildRequest { source: http::Error },
+    #[snafu(display("Blocked request to restricted address: {}", host))]
+    BlockedAddress { host: String },
 }
 
 impl HttpError {
     pub const fn is_retriable(&self) -> bool {
         match self {
             HttpError::BuildRequest { .. } | HttpError::MakeProxyConnector { .. } => false,
+            // Retrying cannot help: the address is in a range this client may never
+            // reach, and that set does not change at runtime.
+            HttpError::BlockedAddress { .. } => false,
             HttpError::CallRequest { .. }
             | HttpError::BuildTlsConnector { .. }
             | HttpError::MakeHttpsConnector { .. } => true,
         }
     }
+}
+
+/// Whether an [`HttpClient`] rejects connections to internal addresses.
+///
+/// Endpoints that come from user configuration are guarded; internal plumbing is not,
+/// since components like the `mezmo` sink legitimately dial a ClusterIP.
+///
+/// Defaults to [`SsrfGuard::Enabled`] so that anything deserialized from a user-supplied
+/// config is guarded whether or not it thought to ask.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SsrfGuard {
+    /// Reject loopback, link-local, private, and reserved destinations.
+    #[default]
+    Enabled,
+    /// Permit any destination.
+    Disabled,
 }
 
 impl UserLoggingError for HttpError {
@@ -82,12 +104,21 @@ impl UserLoggingError for HttpError {
 }
 
 pub type HttpClientFuture = <HttpClient as Service<http::Request<Body>>>::Future;
-type HttpProxyConnector = ProxyConnector<HttpsConnector<HttpConnector>>;
+
+/// The connector every `HttpClient` is built on.
+///
+/// `GuardedResolver` is always in the stack so that guarded and unguarded clients share
+/// one type; whether it actually filters is a runtime flag. See [`crate::ssrf`].
+pub type VectorHttpConnector = HttpConnector<GuardedResolver>;
+type HttpProxyConnector = ProxyConnector<HttpsConnector<VectorHttpConnector>>;
 
 pub struct HttpClient<B = Body> {
     client: Client<HttpProxyConnector, B>,
     user_agent: HeaderValue,
     proxy_connector: HttpProxyConnector,
+    /// Whether to reject requests whose URI is an IP literal in a restricted range.
+    /// Names are handled by the resolver inside `client`; literals never reach it.
+    ssrf_guard: bool,
 }
 
 impl<B> HttpClient<B>
@@ -103,12 +134,47 @@ where
         HttpClient::new_with_custom_client(tls_settings, proxy_config, &mut Client::builder())
     }
 
+    /// Builds a client for endpoints that come from user configuration.
+    ///
+    /// Connections to loopback, link-local, private, and reserved addresses are rejected
+    /// at resolution time, which is what makes this resistant to DNS rebinding: the
+    /// address that gets validated is the address that gets dialed. Use this for any
+    /// component whose destination URL is attacker-controlled. Do not use it for internal
+    /// plumbing (the `mezmo` sink talks to a ClusterIP, for example), which
+    /// legitimately needs to reach those ranges.
+    pub fn new_guarded(
+        tls_settings: impl Into<MaybeTlsSettings>,
+        proxy_config: &ProxyConfig,
+    ) -> Result<HttpClient<B>, HttpError> {
+        HttpClient::build(
+            tls_settings,
+            proxy_config,
+            &mut Client::builder(),
+            SsrfGuard::Enabled,
+        )
+    }
+
     pub fn new_with_custom_client(
         tls_settings: impl Into<MaybeTlsSettings>,
         proxy_config: &ProxyConfig,
         client_builder: &mut client::Builder,
     ) -> Result<HttpClient<B>, HttpError> {
-        let proxy_connector = build_proxy_connector(tls_settings.into(), proxy_config)?;
+        HttpClient::build(
+            tls_settings,
+            proxy_config,
+            client_builder,
+            SsrfGuard::Disabled,
+        )
+    }
+
+    fn build(
+        tls_settings: impl Into<MaybeTlsSettings>,
+        proxy_config: &ProxyConfig,
+        client_builder: &mut client::Builder,
+        guard: SsrfGuard,
+    ) -> Result<HttpClient<B>, HttpError> {
+        let proxy_connector =
+            build_proxy_connector_with_guard(tls_settings.into(), proxy_config, guard)?;
         let client = client_builder.build(proxy_connector.clone());
 
         let version = crate::get_version();
@@ -120,6 +186,7 @@ where
             client,
             user_agent,
             proxy_connector,
+            ssrf_guard: guard == SsrfGuard::Enabled,
         })
     }
 
@@ -129,6 +196,20 @@ where
     ) -> BoxFuture<'static, Result<http::Response<Body>, HttpError>> {
         let span = tracing::info_span!("http");
         let _enter = span.enter();
+
+        // hyper dials an IP-literal URI directly without consulting the resolver, so the
+        // guard in the connector never sees it. Reject it here instead. There is no
+        // check-to-dial gap to worry about: with no name involved, the literal in the URI
+        // is what gets connected to.
+        if self.ssrf_guard
+            && let Some(host) = request.uri().host()
+            && let Ok(addr) = host.trim_start_matches('[').trim_end_matches(']').parse()
+            && crate::ssrf::is_blocked(addr)
+        {
+            return Box::pin(std::future::ready(Err(HttpError::BlockedAddress {
+                host: host.to_owned(),
+            })));
+        }
 
         default_request_headers(&mut request, &self.user_agent);
         self.maybe_add_proxy_headers(&mut request);
@@ -184,12 +265,20 @@ where
 pub fn build_proxy_connector(
     tls_settings: MaybeTlsSettings,
     proxy_config: &ProxyConfig,
-) -> Result<ProxyConnector<HttpsConnector<HttpConnector>>, HttpError> {
+) -> Result<ProxyConnector<HttpsConnector<VectorHttpConnector>>, HttpError> {
+    build_proxy_connector_with_guard(tls_settings, proxy_config, SsrfGuard::Disabled)
+}
+
+fn build_proxy_connector_with_guard(
+    tls_settings: MaybeTlsSettings,
+    proxy_config: &ProxyConfig,
+    guard: SsrfGuard,
+) -> Result<ProxyConnector<HttpsConnector<VectorHttpConnector>>, HttpError> {
     // Create dedicated TLS connector for the proxied connection with user TLS settings.
     let tls = tls_connector_builder(&tls_settings)
         .context(BuildTlsConnectorSnafu)?
         .build();
-    let https = build_tls_connector(tls_settings)?;
+    let https = build_tls_connector_with_guard(tls_settings, guard)?;
     let mut proxy = ProxyConnector::new(https).unwrap();
     // Make proxy connector aware of user TLS settings by setting the TLS connector:
     // https://github.com/vectordotdev/vector/issues/13683
@@ -202,8 +291,16 @@ pub fn build_proxy_connector(
 
 pub fn build_tls_connector(
     tls_settings: MaybeTlsSettings,
-) -> Result<HttpsConnector<HttpConnector>, HttpError> {
-    let mut http = HttpConnector::new();
+) -> Result<HttpsConnector<VectorHttpConnector>, HttpError> {
+    build_tls_connector_with_guard(tls_settings, SsrfGuard::Disabled)
+}
+
+fn build_tls_connector_with_guard(
+    tls_settings: MaybeTlsSettings,
+    guard: SsrfGuard,
+) -> Result<HttpsConnector<VectorHttpConnector>, HttpError> {
+    let mut http =
+        HttpConnector::new_with_resolver(GuardedResolver::new(guard == SsrfGuard::Enabled));
     http.enforce_http(false);
 
     let tls = tls_connector_builder(&tls_settings).context(BuildTlsConnectorSnafu)?;
@@ -261,6 +358,7 @@ impl<B> Clone for HttpClient<B> {
             client: self.client.clone(),
             user_agent: self.user_agent.clone(),
             proxy_connector: self.proxy_connector.clone(),
+            ssrf_guard: self.ssrf_guard,
         }
     }
 }
@@ -715,7 +813,125 @@ mod tests {
     use tower::ServiceBuilder;
 
     use super::*;
-    use crate::test_util::addr::next_addr;
+    use crate::test_util::{
+        addr::{PortGuard, next_addr},
+        wait_for_tcp,
+    };
+
+    /// Serves 200 on a loopback address. Stands in for any internal service a
+    /// user-supplied endpoint must not be able to reach. The returned guard holds the
+    /// port reservation and must be kept alive for the duration of the test.
+    async fn spawn_loopback_server() -> (PortGuard, SocketAddr) {
+        let (guard, addr) = next_addr();
+        let make_svc = make_service_fn(|_: &AddrStream| async {
+            Ok::<_, Infallible>(tower::service_fn(|_req: Request<Body>| async {
+                Ok::<Response<Body>, Infallible>(Response::new(Body::from("internal")))
+            }))
+        });
+        tokio::spawn(async move {
+            Server::bind(&addr).serve(make_svc).await.unwrap();
+        });
+        wait_for_tcp(addr).await;
+        (guard, addr)
+    }
+
+    /// The whole error chain, since a connector failure surfaces nested inside
+    /// `hyper::Error`.
+    fn error_chain(err: &dyn std::error::Error) -> String {
+        let mut chain = err.to_string();
+        let mut source = err.source();
+        while let Some(err) = source {
+            chain.push_str(&format!(": {err}"));
+            source = err.source();
+        }
+        chain
+    }
+
+    #[tokio::test]
+    async fn guarded_client_blocks_ip_literal() {
+        let (_guard, addr) = spawn_loopback_server().await;
+
+        // An IP-literal URI never reaches the resolver, so this exercises the check in
+        // `send`. This is the shape of the original report's first attempt.
+        let req = Request::get(format!("http://{addr}/"))
+            .body(Body::empty())
+            .unwrap();
+        let err = HttpClient::new_guarded(None, &ProxyConfig::default())
+            .unwrap()
+            .send(req)
+            .await
+            .expect_err("loopback literal must be blocked");
+
+        assert!(matches!(err, HttpError::BlockedAddress { .. }), "{err:?}");
+        // Retrying a blocked address can never succeed.
+        assert!(!err.is_retriable());
+    }
+
+    #[tokio::test]
+    async fn guarded_client_blocks_name_resolving_to_internal_address() {
+        let (_guard, addr) = spawn_loopback_server().await;
+
+        // `localhost` resolves to loopback, which is the same thing a rebinding hostname
+        // does at poll time: the connector asks the resolver, and the answer is internal.
+        // Blocking here is what a save-time check cannot do.
+        let req = Request::get(format!("http://localhost:{}/", addr.port()))
+            .body(Body::empty())
+            .unwrap();
+        let err = HttpClient::new_guarded(None, &ProxyConfig::default())
+            .unwrap()
+            .send(req)
+            .await
+            .expect_err("a name resolving to loopback must be blocked");
+
+        assert!(
+            error_chain(&err).contains("restricted ranges"),
+            "expected the resolver to reject, got: {}",
+            error_chain(&err)
+        );
+    }
+
+    #[tokio::test]
+    async fn unguarded_client_still_reaches_internal_addresses() {
+        let (_guard, addr) = spawn_loopback_server().await;
+
+        // Internal plumbing (the `mezmo` sink dialing a ClusterIP, say) must be
+        // unaffected. This is also the control for the two tests above: it proves they
+        // fail because of the guard and not because the server is unreachable.
+        for uri in [
+            format!("http://{addr}/"),
+            format!("http://localhost:{}/", addr.port()),
+        ] {
+            let req = Request::get(&uri).body(Body::empty()).unwrap();
+            let response = HttpClient::new(None, &ProxyConfig::default())
+                .unwrap()
+                .send(req)
+                .await
+                .unwrap_or_else(|err| panic!("{uri} must be reachable: {err:?}"));
+
+            assert_eq!(response.status(), hyper::StatusCode::OK);
+        }
+    }
+
+    #[tokio::test]
+    async fn guarded_client_reaches_public_addresses() {
+        // The guard must only remove internal destinations. A public name still resolves
+        // and connects; we only assert the guard does not reject it before dialing.
+        let req = Request::get("http://example.com/")
+            .body(Body::empty())
+            .unwrap();
+        let result = HttpClient::new_guarded(None, &ProxyConfig::default())
+            .unwrap()
+            .send(req)
+            .await;
+
+        if let Err(err) = result {
+            let chain = error_chain(&err);
+            assert!(
+                !chain.contains("restricted ranges") && !chain.contains("restricted address"),
+                "a public endpoint must not be blocked by the guard, got: {chain}"
+            );
+        }
+    }
 
     #[test]
     fn test_default_request_headers_defaults() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ pub(crate) mod sink_ext;
 pub mod sinks;
 #[allow(unreachable_pub)]
 pub mod sources;
+pub mod ssrf;
 pub mod stats;
 #[cfg(feature = "api-client")]
 #[allow(unreachable_pub)]

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -1,5 +1,4 @@
 use http::Uri;
-use hyper::client::HttpConnector;
 use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
 use tonic::body::BoxBody;
@@ -16,7 +15,7 @@ use crate::{
         AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext,
         SinkHealthcheckOptions,
     },
-    http::build_proxy_connector,
+    http::{VectorHttpConnector, build_proxy_connector},
     proto::vector as proto,
     sinks::{
         Healthcheck, VectorSink as VectorSinkType,
@@ -209,7 +208,7 @@ pub fn with_default_scheme(address: &str, tls: bool) -> crate::Result<Uri> {
 fn new_client(
     tls_settings: &MaybeTlsSettings,
     proxy_config: &ProxyConfig,
-) -> crate::Result<hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>> {
+) -> crate::Result<hyper::Client<ProxyConnector<HttpsConnector<VectorHttpConnector>>, BoxBody>> {
     let proxy = build_proxy_connector(tls_settings.clone(), proxy_config)?;
 
     Ok(hyper::Client::builder().http2_only(true).build(proxy))

--- a/src/sinks/vector/service.rs
+++ b/src/sinks/vector/service.rs
@@ -2,7 +2,6 @@ use std::task::{Context, Poll};
 
 use futures::{TryFutureExt, future::BoxFuture};
 use http::Uri;
-use hyper::client::HttpConnector;
 use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
 use prost::Message;
@@ -17,6 +16,7 @@ use super::VectorSinkError;
 use crate::{
     Error,
     event::{EventFinalizers, EventStatus, Finalizable},
+    http::VectorHttpConnector,
     internal_events::EndpointBytesSent,
     proto::vector as proto_vector,
     sinks::util::uri,
@@ -68,7 +68,7 @@ impl MetaDescriptive for VectorRequest {
 
 impl VectorService {
     pub fn new(
-        hyper_client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
+        hyper_client: hyper::Client<ProxyConnector<HttpsConnector<VectorHttpConnector>>, BoxBody>,
         uri: Uri,
         compression: bool,
     ) -> Self {
@@ -135,7 +135,7 @@ impl Service<VectorRequest> for VectorService {
 #[derive(Clone, Debug)]
 pub struct HyperSvc {
     uri: Uri,
-    client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
+    client: hyper::Client<ProxyConnector<HttpsConnector<VectorHttpConnector>>, BoxBody>,
 }
 
 impl Service<hyper::Request<BoxBody>> for HyperSvc {

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -30,7 +30,7 @@ use crate::{
     codecs::{Decoder, DecodingConfig},
     config::{SourceConfig, SourceContext},
     format_vrl_diagnostics,
-    http::{Auth, ParamType, ParameterValue, QueryParameterValue, QueryParameters},
+    http::{Auth, ParamType, ParameterValue, QueryParameterValue, QueryParameters, SsrfGuard},
     serde::{default_decoding, default_framing_message_based},
     sources,
     sources::util::{
@@ -135,6 +135,13 @@ pub struct HttpClientConfig {
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     pub log_namespace: Option<bool>,
+
+    // `endpoint` is user-supplied, so the destination is untrusted and this is always
+    // `Enabled` in production. It is `serde(skip)` deliberately: a config must not be
+    // able to turn the guard off, or it would hand back the very hole it closes. Tests
+    // that legitimately point the source at a loopback server set it in code.
+    #[serde(skip)]
+    pub ssrf_guard: SsrfGuard,
 }
 
 const fn default_http_method() -> HttpMethod {
@@ -236,6 +243,7 @@ impl Default for HttpClientConfig {
             tls: None,
             auth: None,
             log_namespace: None,
+            ssrf_guard: SsrfGuard::Enabled,
         }
     }
 }
@@ -390,6 +398,7 @@ impl SourceConfig for HttpClientConfig {
             tls,
             proxy: cx.proxy.clone(),
             shutdown: cx.shutdown,
+            ssrf_guard: self.ssrf_guard,
         };
 
         Ok(call(inputs, context, cx.out, self.method).boxed())

--- a/src/sources/http_client/integration_tests.rs
+++ b/src/sources/http_client/integration_tests.rs
@@ -14,7 +14,7 @@ use super::{
 use crate::{
     SourceSender,
     config::{ComponentKey, SourceConfig, SourceContext},
-    http::Auth,
+    http::{Auth, SsrfGuard},
     serde::{default_decoding, default_framing_message_based},
     sources::util::http::HttpMethod,
     test_util::components::{COMPONENT_ERROR_TAGS, run_and_assert_source_error},
@@ -60,6 +60,7 @@ async fn invalid_endpoint() {
         auth: None,
         tls: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -80,6 +81,7 @@ async fn collected_logs_bytes() {
         auth: None,
         tls: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
     // panics if not log event
@@ -106,6 +108,7 @@ async fn collected_logs_json() {
         auth: None,
         tls: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
     // panics if not log event
@@ -132,6 +135,7 @@ async fn collected_metrics_native_json() {
         auth: None,
         tls: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 
@@ -163,6 +167,7 @@ async fn collected_trace_native_json() {
         auth: None,
         tls: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 
@@ -189,6 +194,7 @@ async fn unauthorized_no_auth() {
         auth: None,
         tls: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -212,6 +218,7 @@ async fn unauthorized_wrong_auth() {
             password: "morpheus".to_string().into(),
         }),
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -235,6 +242,7 @@ async fn authorized() {
             password: "pass".to_string().into(),
         }),
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -258,6 +266,7 @@ async fn tls_invalid_ca() {
         }),
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -281,6 +290,7 @@ async fn tls_valid() {
         }),
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -302,6 +312,7 @@ async fn shutdown() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     };
 
     // build the context for the source and get a SourceShutdownCoordinator to signal with

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -15,12 +15,14 @@ use warp::{Filter, http::HeaderMap};
 use super::HttpClientConfig;
 use crate::{
     components::validation::prelude::*,
-    http::{ParamType, ParameterValue, QueryParameterValue},
+    http::{ParamType, ParameterValue, QueryParameterValue, SsrfGuard},
     serde::{default_decoding, default_framing_message_based},
     sources::util::http::HttpMethod,
     test_util::{
         addr::next_addr,
-        components::{HTTP_PULL_SOURCE_TAGS, run_and_assert_source_compliance},
+        components::{
+            HTTP_PULL_SOURCE_TAGS, run_and_assert_source_compliance, run_and_assert_source_error,
+        },
         test_generate_config, wait_for_tcp,
     },
 };
@@ -78,6 +80,43 @@ impl ValidatableComponent for HttpClientConfig {
 
 register_validatable_component!(HttpClientConfig);
 
+/// The guard is on by default, so a source pointed at an internal address ingests
+/// nothing and reports an error per poll.
+///
+/// Every other test here sets `ssrf_guard: Disabled` to reach its own loopback server.
+/// This one deliberately does not, so the wiring that actually closes VM-713 cannot
+/// regress unnoticed.
+#[tokio::test]
+async fn ssrf_guard_blocks_internal_endpoint_by_default() {
+    let (_guard, in_addr) = next_addr();
+
+    let dummy_endpoint = warp::path!("endpoint").map(|| r#"{"secret":"internal-only"}"#);
+    tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
+    wait_for_tcp(in_addr).await;
+
+    let config = HttpClientConfig {
+        endpoint: format!("http://{in_addr}/endpoint"),
+        interval: INTERVAL,
+        timeout: TIMEOUT,
+        ..Default::default()
+    };
+
+    // What a config deserialized from a user's pipeline gets.
+    assert_eq!(config.ssrf_guard, SsrfGuard::Enabled);
+
+    let events = run_and_assert_source_error(
+        config,
+        Duration::from_secs(3),
+        &["url", "error_type", "stage"],
+    )
+    .await;
+
+    assert!(
+        events.is_empty(),
+        "an endpoint resolving to a restricted address must not ingest anything, got: {events:?}"
+    );
+}
+
 /// Bytes should be decoded and HTTP header set to text/plain.
 #[tokio::test]
 async fn bytes_decoding() {
@@ -103,6 +142,7 @@ async fn bytes_decoding() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -133,6 +173,7 @@ async fn json_decoding_newline_delimited() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -168,6 +209,7 @@ async fn json_decoding_character_delimited() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -209,6 +251,7 @@ async fn request_query_applied() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 
@@ -321,6 +364,7 @@ async fn request_query_vrl_applied() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 
@@ -403,6 +447,7 @@ async fn request_query_vrl_dynamic_updates() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 
@@ -471,6 +516,7 @@ async fn headers_applied() {
         auth: None,
         tls: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -501,6 +547,7 @@ async fn accept_header_override() {
         auth: None,
         tls: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -538,6 +585,7 @@ async fn post_with_body() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 
@@ -579,6 +627,7 @@ async fn post_without_body() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -609,6 +658,7 @@ async fn post_with_custom_content_type() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 }
@@ -646,6 +696,7 @@ async fn post_with_vrl_body() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     })
     .await;
 
@@ -687,6 +738,7 @@ async fn query_vrl_compilation_error() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     };
 
     // Attempt to build the source - should fail
@@ -730,6 +782,7 @@ async fn body_vrl_compilation_error() {
         tls: None,
         auth: None,
         log_namespace: None,
+        ssrf_guard: SsrfGuard::Disabled,
     };
 
     // Attempt to build the source - should fail

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -11,7 +11,7 @@ use super::parser;
 use crate::{
     Result,
     config::{GenerateConfig, SourceConfig, SourceContext, SourceOutput},
-    http::{Auth, QueryParameters},
+    http::{Auth, QueryParameters, SsrfGuard},
     internal_events::PrometheusParseError,
     sources::{
         self,
@@ -159,6 +159,9 @@ impl SourceConfig for PrometheusScrapeConfig {
             tls,
             proxy: cx.proxy.clone(),
             shutdown: cx.shutdown,
+            // Unguarded: scrape targets are routinely internal, and this source is not
+            // exposed as a user-configurable pipeline component. Revisit if it ever is.
+            ssrf_guard: SsrfGuard::Disabled,
         };
 
         Ok(call(inputs, builder, cx.out, HttpMethod::Get).boxed())

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -25,7 +25,7 @@ use vector_lib::{
 
 use crate::{
     SourceSender,
-    http::{Auth, HttpClient, QueryParameterValue, QueryParameters},
+    http::{Auth, HttpClient, QueryParameterValue, QueryParameters, SsrfGuard},
     internal_events::{
         EndpointBytesReceived, HttpClientBuildError, HttpClientEventsReceived, HttpClientHttpError,
         HttpClientHttpResponseError, StreamClosedError,
@@ -50,6 +50,12 @@ pub(crate) struct GenericHttpClientInputs {
     pub tls: TlsSettings,
     pub proxy: ProxyConfig,
     pub shutdown: ShutdownSignal,
+    /// Whether to reject connections to internal addresses.
+    ///
+    /// Enable this whenever the URL comes from user configuration: the check happens at
+    /// resolution time, which is what stops a hostname from resolving public for a
+    /// config-time check and internal for the actual poll.
+    pub ssrf_guard: SsrfGuard,
 }
 
 /// The default interval to call the HTTP endpoint if none is configured.
@@ -158,8 +164,11 @@ pub(crate) async fn call<
 ) -> Result<(), ()> {
     // Building the HttpClient should not fail as it is just setting up the client with the
     // proxy and tls settings.
-    let client =
-        HttpClient::new(inputs.tls.clone(), &inputs.proxy).expect("Building HTTP client failed");
+    let client = match inputs.ssrf_guard {
+        SsrfGuard::Enabled => HttpClient::new_guarded(inputs.tls.clone(), &inputs.proxy),
+        SsrfGuard::Disabled => HttpClient::new(inputs.tls.clone(), &inputs.proxy),
+    }
+    .expect("Building HTTP client failed");
     let mut stream = IntervalStream::new(tokio::time::interval(inputs.interval))
         .take_until(inputs.shutdown)
         .map(move |_| stream::iter(inputs.urls.clone()))

--- a/src/ssrf.rs
+++ b/src/ssrf.rs
@@ -1,0 +1,312 @@
+//! SSRF guard for HTTP clients that dial user-supplied endpoints.
+//!
+//! The endpoint of a component such as the `http_client` source is attacker-controlled:
+//! a tenant can point it at any hostname. Validating that hostname when the config is
+//! saved is not enough, because DNS is re-resolved on every connection and the answer
+//! can change between the check and the dial (DNS rebinding). A check that is not bound
+//! to the connection is advisory.
+//!
+//! This module moves the check to the point where the name is actually resolved, so what
+//! gets validated is what gets connected to.
+//!
+//! Note that hyper's `HttpConnector` only consults the resolver for hostnames: a URI that
+//! is already an IP literal is parsed and dialed directly. Literals are therefore checked
+//! separately, where the request is issued (see `HttpClient::send`). That check is not
+//! subject to rebinding, since no name resolution is involved.
+
+use std::{
+    io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    task::{Context, Poll},
+};
+
+use futures::{FutureExt, future::BoxFuture};
+use hyper::client::connect::dns::{GaiResolver, Name};
+use tower::Service;
+use tracing::warn;
+
+/// Returns `true` if `addr` is in a range a user-supplied endpoint must never reach:
+/// loopback, link-local (the cloud metadata service lives at `169.254.169.254`), private
+/// networks, and the various reserved or special-purpose blocks.
+///
+/// This set is fixed by RFC. It is deliberately not configurable.
+pub fn is_blocked(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(addr) => is_blocked_v4(addr),
+        IpAddr::V6(addr) => is_blocked_v6(addr),
+    }
+}
+
+fn is_blocked_v4(addr: Ipv4Addr) -> bool {
+    let [a, b, c, _] = addr.octets();
+    match a {
+        // "This network" (RFC 1122)
+        0 => true,
+        // Private (RFC 1918)
+        10 => true,
+        // Shared address space / CGNAT (RFC 6598)
+        100 => (64..=127).contains(&b),
+        // Loopback (RFC 1122)
+        127 => true,
+        // Link-local, which includes the cloud metadata service (RFC 3927)
+        169 => b == 254,
+        // Private (RFC 1918)
+        172 => (16..=31).contains(&b),
+        192 => match (b, c) {
+            // IETF protocol assignments (RFC 6890)
+            (0, 0) => true,
+            // TEST-NET-1 (RFC 5737)
+            (0, 2) => true,
+            // 6to4 relay anycast (RFC 3068)
+            (88, 99) => true,
+            // Private (RFC 1918)
+            (168, _) => true,
+            _ => false,
+        },
+        198 => match (b, c) {
+            // Benchmarking (RFC 2544)
+            (18 | 19, _) => true,
+            // TEST-NET-2 (RFC 5737)
+            (51, 100) => true,
+            _ => false,
+        },
+        // TEST-NET-3 (RFC 5737)
+        203 => b == 0 && c == 113,
+        // Multicast (RFC 5771). Also covers 233.252.0.0/24 (MCAST-TEST-NET).
+        224..=239 => true,
+        // Reserved (RFC 1112), including the broadcast address
+        240..=255 => true,
+        _ => false,
+    }
+}
+
+fn is_blocked_v6(addr: Ipv6Addr) -> bool {
+    // These must be judged before unwrapping to IPv4: `::1` and `::` are themselves
+    // IPv4-compatible addresses and would otherwise unwrap to 0.0.0.1 and 0.0.0.0.
+    if addr.is_loopback() || addr.is_unspecified() || addr.is_multicast() {
+        return true;
+    }
+
+    // IPv4-mapped (`::ffff:a.b.c.d`) and the deprecated IPv4-compatible (`::a.b.c.d`)
+    // forms both reach an IPv4 destination, so they are judged as IPv4. Without this,
+    // `::ffff:169.254.169.254` walks straight past the v6 checks.
+    if let Some(v4) = addr.to_ipv4() {
+        return is_blocked_v4(v4);
+    }
+
+    let segments = addr.segments();
+
+    // The NAT64 well-known prefix (RFC 6052) embeds the IPv4 destination.
+    if segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2..6] == [0, 0, 0, 0] {
+        let [a, b] = segments[6].to_be_bytes();
+        let [c, d] = segments[7].to_be_bytes();
+        return is_blocked_v4(Ipv4Addr::new(a, b, c, d));
+    }
+
+    let octets = addr.octets();
+
+    // Unique local (RFC 4193)
+    (octets[0] & 0xfe) == 0xfc
+        // Link-local unicast (RFC 4291)
+        || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80)
+        // Site-local (RFC 3513). Deprecated by RFC 3879, but a deprecated prefix is
+        // still a routable one: hosts and routers that predate the deprecation still
+        // answer on it, so it stays reachable from the worker and must be rejected.
+        || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0xc0)
+        // Documentation (RFC 3849)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        // Discard-only (RFC 6666)
+        || (segments[0] == 0x0100 && segments[1..4] == [0, 0, 0])
+}
+
+/// Wraps hyper's system resolver and drops any address that a user-supplied endpoint is
+/// not permitted to reach.
+///
+/// The guard is a runtime flag rather than a separate type so that guarded and unguarded
+/// clients share a single connector type, which keeps `HttpClient` concrete and leaves
+/// every existing caller untouched.
+#[derive(Clone)]
+pub struct GuardedResolver {
+    inner: GaiResolver,
+    enabled: bool,
+}
+
+impl GuardedResolver {
+    /// Creates a resolver. When `enabled` is false this defers to the system resolver
+    /// and filters nothing.
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            inner: GaiResolver::new(),
+            enabled,
+        }
+    }
+}
+
+impl Service<Name> for GuardedResolver {
+    type Response = std::vec::IntoIter<SocketAddr>;
+    type Error = io::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, name: Name) -> Self::Future {
+        let enabled = self.enabled;
+        let host = name.as_str().to_owned();
+        let lookup = self.inner.call(name);
+
+        async move {
+            let addrs = lookup.await?;
+
+            if !enabled {
+                return Ok(addrs.collect::<Vec<_>>().into_iter());
+            }
+
+            let (permitted, blocked): (Vec<_>, Vec<_>) =
+                addrs.partition(|addr| !is_blocked(addr.ip()));
+
+            if !blocked.is_empty() {
+                warn!(
+                    message = "Blocked a resolved address in a restricted range for a user-supplied endpoint.",
+                    host = %host,
+                    blocked = ?blocked.iter().map(|addr| addr.ip()).collect::<Vec<_>>(),
+                );
+            }
+
+            if permitted.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("{host} resolves only to addresses in restricted ranges"),
+                ));
+            }
+
+            Ok(permitted.into_iter())
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blocked(addr: &str) -> bool {
+        is_blocked(addr.parse::<IpAddr>().expect("valid address"))
+    }
+
+    #[test]
+    fn blocks_cloud_metadata() {
+        // The address the VM-713 report read IAM credentials from.
+        assert!(blocked("169.254.169.254"));
+        assert!(blocked("169.254.0.1"));
+    }
+
+    #[test]
+    fn blocks_loopback() {
+        // The Vector GraphQL control-plane leg of the same report.
+        assert!(blocked("127.0.0.1"));
+        assert!(blocked("127.1.2.3"));
+        assert!(blocked("::1"));
+    }
+
+    #[test]
+    fn blocks_private_ranges() {
+        assert!(blocked("10.0.0.1"));
+        assert!(blocked("172.16.0.1"));
+        assert!(blocked("172.31.255.255"));
+        assert!(blocked("192.168.1.1"));
+        assert!(blocked("100.64.0.1"));
+    }
+
+    #[test]
+    fn allows_public_addresses() {
+        assert!(!blocked("1.1.1.1"));
+        assert!(!blocked("8.8.8.8"));
+        assert!(!blocked("93.184.216.34"));
+        // Adjacent to private ranges but outside them.
+        assert!(!blocked("172.15.255.255"));
+        assert!(!blocked("172.32.0.0"));
+        assert!(!blocked("100.63.255.255"));
+        assert!(!blocked("100.128.0.0"));
+        assert!(!blocked("169.253.255.255"));
+        assert!(!blocked("2606:4700:4700::1111"));
+    }
+
+    #[test]
+    fn blocks_ipv4_mapped_and_compatible_forms() {
+        // An IPv4-mapped address reaches the same host, so it must be judged as IPv4.
+        assert!(blocked("::ffff:169.254.169.254"));
+        assert!(blocked("::ffff:127.0.0.1"));
+        assert!(blocked("::ffff:10.0.0.1"));
+        assert!(!blocked("::ffff:1.1.1.1"));
+    }
+
+    #[test]
+    fn blocks_nat64_embedded_targets() {
+        // 64:ff9b::169.254.169.254
+        assert!(blocked("64:ff9b::a9fe:a9fe"));
+        // 64:ff9b::127.0.0.1
+        assert!(blocked("64:ff9b::7f00:1"));
+        // 64:ff9b::1.1.1.1 embeds a public target.
+        assert!(!blocked("64:ff9b::101:101"));
+    }
+
+    #[test]
+    fn blocks_ipv6_internal_ranges() {
+        assert!(blocked("::"));
+        assert!(blocked("fc00::1"));
+        assert!(blocked("fd12:3456::1"));
+        assert!(blocked("fe80::1"));
+        assert!(blocked("febf:ffff::1"));
+        // Site-local (fec0::/10): deprecated, still routable.
+        assert!(blocked("fec0::1"));
+        assert!(blocked("feff:ffff::1"));
+        assert!(blocked("ff02::1"));
+        assert!(blocked("2001:db8::1"));
+        assert!(blocked("100::1"));
+    }
+
+    #[test]
+    fn blocks_reserved_and_special_ranges() {
+        assert!(blocked("0.0.0.0"));
+        assert!(blocked("0.1.2.3"));
+        assert!(blocked("192.0.0.1"));
+        assert!(blocked("192.0.2.1"));
+        assert!(blocked("192.88.99.1"));
+        assert!(blocked("198.18.0.1"));
+        assert!(blocked("198.19.255.255"));
+        assert!(blocked("198.51.100.1"));
+        assert!(blocked("203.0.113.1"));
+        assert!(blocked("224.0.0.1"));
+        assert!(blocked("233.252.0.1"));
+        assert!(blocked("240.0.0.1"));
+        assert!(blocked("255.255.255.255"));
+    }
+
+    #[tokio::test]
+    async fn resolver_rejects_internal_only_name() {
+        let mut resolver = GuardedResolver::new(true);
+        let name: Name = "localhost".parse().expect("valid name");
+
+        let err = resolver
+            .call(name)
+            .await
+            .expect_err("localhost resolves only to loopback and must be rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn disabled_resolver_permits_internal_name() {
+        let mut resolver = GuardedResolver::new(false);
+        let name: Name = "localhost".parse().expect("valid name");
+
+        let addrs = resolver
+            .call(name)
+            .await
+            .expect("guard is disabled, so loopback must resolve");
+
+        assert!(addrs.count() > 0);
+    }
+}


### PR DESCRIPTION
The endpoint is user-supplied but was only validated at config-save time, so a hostname could answer public for that check and internal for every poll. The guard now runs at resolution, binding the check to the address actually dialed, and `send` covers IP literals since hyper never routes those through the resolver. Only the http_client source opts in -- internal plumbing like the mezmo sink still dials ClusterIPs.

Ref: VM-713

