### PR TITLE
fix(builds): normal build shouldn't include debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -757,12 +757,16 @@ version: ## Get the current Vector version
 .PHONY:mezmo-build-image
 mezmo-build-image:
 	@echo "Building image us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}"
-	docker build -t "us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}" --build-arg BUILD_VERSION=${BUILD_VERSION} -f distribution/docker/mezmo/Dockerfile --platform=linux/amd64 --progress=plain .
+	docker build -t "us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}" --target release --build-arg BUILD_VERSION=${BUILD_VERSION} -f distribution/docker/mezmo/Dockerfile --platform=linux/amd64 --progress=plain .
+	@echo "Building debug image us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}-debug"
+	docker build -t "us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}-debug" --target release-debug --build-arg BUILD_VERSION=${BUILD_VERSION} -f distribution/docker/mezmo/Dockerfile --platform=linux/amd64 --progress=plain .
 
 .PHONY:mezmo-publish-image
 mezmo-publish-image:
 	@echo "Publishing image us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}"
 	docker push "us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}"
+	@echo "Publishing debug image us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}-debug"
+	docker push "us.gcr.io/logdna-k8s/vector:${BUILD_VERSION}-debug"
 
 .PHONY: git-hooks
 git-hooks: ## Add Vector-local git hooks for commit sign-off

--- a/distribution/docker/mezmo/Dockerfile
+++ b/distribution/docker/mezmo/Dockerfile
@@ -29,27 +29,36 @@ RUN cat /etc/os-release
 ENV RELEASE_VERSION=${RELEASE_VERSION}
 RUN cargo build --release
 
+# The compile leaves the line-table debug info from `[profile.release] debug = 1`
+# embedded, which inflates the binary to well over 1GB. Keep the full binary
+# (`vector.full`) for the debug image, where gdb and the jeprof heap-profile
+# tooling symbolize against it, and strip a copy for the ordinary runtime image
+# so routine pulls/deploys move a fraction of the bytes.
+RUN cp target/release/vector target/release/vector.full \
+  && strip --strip-all target/release/vector
+
 RUN ls -lh /build/target/release
 
-# Smoke test on relese-builder
+# Smoke test on release-builder
 RUN ["/build/target/release/vector", "--version"]
 
-# use internal base image
-FROM us.gcr.io/logdna-k8s/release:trixie AS release
+# Shared runtime base for both the release and debug images. The vector binary
+# is added by each leaf stage because they ship different builds (stripped vs
+# full), so it is intentionally not copied here.
+FROM us.gcr.io/logdna-k8s/release:trixie AS runtime-base
+ARG BUILD_DATE
+ARG VCS_REF
+ARG BUILD_VERSION
 
 # install remaining dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends systemd gdb \
+RUN apt-get update && apt-get install -y --no-install-recommends systemd \
   && apt-get autoremove -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc
 
-COPY --from=release-builder /build/target/release/vector /usr/local/bin/vector
 RUN mkdir -p /var/lib/vector
 RUN mkdir -p /etc/protobuf_descs
 COPY distribution/docker/mezmo/opentelemetry-proto.desc /etc/protobuf_descs/opentelemetry-proto.desc
-
-RUN ["gdb", "--version"]
-RUN ["vector", "--version"]
 
 LABEL org.opencontainers.image.title="answerbook/vector"
 LABEL org.opencontainers.image.description="Mezmo vector fork"
@@ -62,3 +71,24 @@ LABEL org.opencontainers.image.version="${BUILD_VERSION}"
 LABEL org.opencontainers.image.revision="${VCS_REF}"
 
 ENTRYPOINT ["vector"]
+
+# Debug image (built on demand via `--target release-debug`): ships the full,
+# unstripped binary plus gdb so a debugger can attach and the jeprof tooling can
+# symbolize heap dumps against /usr/local/bin/vector exactly as before.
+FROM runtime-base AS release-debug
+RUN apt-get update && apt-get install -y --no-install-recommends gdb \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc
+
+COPY --from=release-builder /build/target/release/vector.full /usr/local/bin/vector
+
+RUN ["gdb", "--version"]
+RUN ["vector", "--version"]
+
+# Default runtime image: stripped binary only, no debugger. This is the last
+# stage, so a build with no `--target` produces it (unchanged behavior for the
+# existing Jenkins/buildx builds, now with a much smaller binary).
+FROM runtime-base AS release
+COPY --from=release-builder /build/target/release/vector /usr/local/bin/vector
+RUN ["vector", "--version"]

--- a/jeprof/build/Dockerfile
+++ b/jeprof/build/Dockerfile
@@ -1,6 +1,9 @@
 ARG VERSION # Should match the deployed image version
 
-FROM us.gcr.io/logdna-k8s/vector:${VERSION}
+# The `-debug` variant ships the full, unstripped binary. The ordinary
+# `:${VERSION}` image is stripped (strip --strip-all) and cannot be symbolized,
+# so jeprof must read symbols from the debug image.
+FROM us.gcr.io/logdna-k8s/vector:${VERSION}-debug
 RUN apt update && apt install -y curl git graphviz build-essential libjemalloc-dev
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN /root/.cargo/bin/cargo install --examples addr2line


### PR DESCRIPTION
create two different container images. the first should be a normal runtime image.  the second needs to persist the debugging capabilities of the current image.

